### PR TITLE
sync gimp-fourier-plugin and other misc refinements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        choiceL: [--disable-silent-rules]
+        choiceL: [--disable-silent-rules, --enable-silent-rules]
     steps:
       - uses: actions/checkout@v2
       - name: Create configure

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,9 +17,13 @@ fourierdocsdir = ${datarootdir}/gimp-fourier-plugin
 fourierdocs_DATA = LICENSE README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
-	README.md README.Moire	     	\
-	packaging/gimp-fourier-plugin.spec.in	\
-	packaging/gimp-fourier-plugin.spec
+	README.md README.Moire			\
+	debian/changelog debian/compat		\
+	debian/control debian/copyright		\
+	debian/fourier-docs.docs debian/rules	\
+	debian/source/format			\
+	rpm/gimp-fourier-plugin.spec.in		\
+	rpm/gimp-fourier-plugin.spec
 nodist_EXTRA_DATA = .git .github
 DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ msys2 -mingw32 -c 'echo $(gimptool-2.0 -n --build fourier.c) -lfftw3 -O3 | sh'
 This is for 32bits version ; replace i686 by x84_64 and -mingw32 by -mingw64 if you want 64bits. 
 Replace also 2.10.24 by your GIMP version (or leave empty for latest version)
 
-Also, the windows binaries are build through GitHub Actions. So you may also fork this repository and build the plugin on your own.
+Also, the windows binaries are built through GitHub Actions, so you may also fork this repository and build the plugin on your own.
 
 
 ## Maintainers:
 
-To create a distributable fourier-{version}.tar.gz file, you  will need to do these steps:
+To create a distributable gimp-fourier-plugin-{version}.tar.gz file, you  will need to do these steps:
 First, update the MAJOR.MINOR version in configure.ac, and then:
 
 ```
@@ -86,17 +86,25 @@ $ ./configure
 $ make dist
 $ ls -l
 ```
-
-You should see a tar file named fourier-0.4.3.tar.gz in the directory. Ccopy fourier-0.4.3.tar.gz to your release webpage.
-
+You should see a tar file named gimp-fourier-plugin-0.4.4.tar.gz in the same directory.
+To verify that the dist package contains all files and nothing is missing, test build it....
+```
+$ tar -xzf gimp-fourier-plugin-0.4.4.tar.gz
+$ cd gimp-fourier-plugin-0.4.4
+$ ./configure --bindir=/usr/lib/gimp/2.0/plug-ins
+$ make
+$ sudo make install
+```
+If no errors, then copy gimp-fourier-plugin-0.4.4.tar.gz to your release webpage.
+NOTE: rpm spec file Source0 URL links to this file.
 
 ## History
 
 ```
 *  v0.4.4 (Aug 2022): 
     - Replaced deprecated functions
-    - Autotools toolchain and spec file by JoesCat
-    - Github action workflow to build plugin
+    - Autotools toolchain and initial_rpm.spec file by Joe Da Silva
+    - Github action workflow to build gimp-fourier-plugin
 *  v0.4.3 (Apr 2014); Makefile patch by bluedxca93 (-lm arg for ubuntu 13.04)
 *  v0.4.2 (Feb 2012); Makefile patch by Bob Barry (gcc arg order)
 *  v0.4.1 (Jan 2010): Patch by Martin Ramshaw

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_PREREQ([2.68])
 m4_define([fourier_major_version], [0.4])
 m4_define([fourier_minor_version], [4])
 m4_define([fourier_version],[fourier_major_version.fourier_minor_version])
-m4_define([fourier_package_name], [fourier])
+m4_define([fourier_package_name], [gimp-plugin-fourier])
 
 #--------------------------------------------------------------------------
 AC_INIT([fourier],[fourier_version],[https://github.com/rpeyron/plugin-gimp-fourier/issues],
@@ -152,7 +152,7 @@ AH_BOTTOM([
 #--------------------------------------------------------------------------
 AC_CONFIG_FILES([
 Makefile
-packaging/gimp-fourier-plugin.spec
+rpm/gimp-fourier-plugin.spec
 ])
 AC_OUTPUT
 AC_MSG_NOTICE([

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Rémi Peyronnet <remi+fourier@via.ecp.fr>
 Build-Depends: autotools-dev, libfftw3-dev, libgimp2.0-dev
 Standards-Version: 4.5.1
-Homepage: <insert the upstream URL, if relevant>
+Homepage: https://www.lprp.fr/gimp_plugin_en/
 #Vcs-Browser: https://salsa.debian.org/debian/fourier
 #Vcs-Git: https://salsa.debian.org/debian/fourier.git
 Rules-Requires-Root: no
@@ -13,9 +13,9 @@ Package: gimp-plugin-fourier
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: GIMP Plugin to do forward and reverse Fourier Transform
-  This GIMP plugin will adds 2 items in the filters menu 
+  This GIMP plugin will add 2 items in the filters menu 
   Filters/Generic/FFT Forward and Filters/Generic/FFT Inverse
   It does a direct and reverse Fourier Transform.
   It allows you to work in the frequency domain.
   For instance, it can be used to remove moiré patterns from images 
-  scanned from books. See README.Moire
+  scanned from books (See README.Moire), or regular banding noise.

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,20 +5,10 @@ Source: https://github.com/rpeyron/plugin-gimp-fourier
 
 Files: *
 Copyright: 2002-2022 Rémi Peyronnet <remi+fourier@via.ecp.fr>
-License: GPL-2+
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
- .
- This package is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- .
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <https://www.gnu.org/licenses/>
- .
- On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
+License-Grant:
+ This file is free software;
+ you can redistribute it and/or modify it
+ under the terms of the GNU General Public License
+ as published by the Free Software Foundation;
+ either version 3, or (at your option) any later version.
+License: GPL-3+

--- a/rpm/gimp-fourier-plugin.spec.in
+++ b/rpm/gimp-fourier-plugin.spec.in
@@ -6,14 +6,14 @@
 # package are under the same license as the package itself.
 # Modified for autoconf style build by Joe Da Silva (v0.4.3)
 #
-Name:		fourier
+Name:		gimp-plugin-fourier
 Version:	@FOURIER_VERSION@
 Release:	0
 Summary:	Do direct and reverse Fourier Transforms on your image
 License:	GPLv3+
 URL:		https://www.lprp.fr/gimp_plugin_en/
 Group:          Productivity/Graphics/Bitmap Editors
-Source0:	https://github.com/rpeyron/plugin-gimp-fourier/releases/download/v%{version}/fourier-%{version}.tar.gz
+Source0:	https://github.com/rpeyron/plugin-gimp-fourier/releases/download/v%{version}/gimp-plugin-fourier-%{version}.tar.gz
 BuildRequires:	autoconf
 BuildRequires:	automake
 BuildRequires:	gcc
@@ -24,7 +24,7 @@ Requires:       gimp
 Requires:       libfftw3
 
 %description
-A simple plug-in to do fourier transform on your image. The major advantage
+GIMP Plugin to do forward and reverse Fourier Transform. The major advantage
 of this plugin is to be able to work with the transformed image inside GIMP.
 You can draw or apply filters in fourier space and get the modified image
 with an inverse fourier transform.
@@ -48,7 +48,7 @@ Useful in fixing moire patterns or fixing some regular banding noise.
 
 %files
 %doc %{_datadir}/gimp-fourier-plugin/LICENSE
-%doc %{_datadir}/gimp-fourier-plugin/README
+%doc %{_datadir}/gimp-fourier-plugin/README.md
 %doc %{_datadir}/gimp-fourier-plugin/README.Moire
 %{_libdir}/gimp/2.0/plug-ins/fourier
 


### PR DESCRIPTION
More refinements added.

when you eventually are ready to create a release,
tag = v0.4.4 will set the next release URL, and dist file = gimp-fourier-plugin-0.4.4.tar.gz will match with Source0 in the rpm spec file too.