### PR TITLE
Updated configure/make to use GIMP3 and GTK3, also added locale support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,15 +8,15 @@ jobs:
       matrix:
         choiceL: [--disable-silent-rules, --enable-silent-rules]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create configure
         run: |
           sudo apt-get update -y
-          sudo apt-get install autoconf automake libtool gcc libfftw3-dev libgimp2.0-dev
+          sudo apt-get install autoconf automake libtool gcc libfftw3-dev libgimp-3.0-dev
           autoreconf -i
           automake
       - name: Choose configure
-        run: ./configure ${{ matrix.choiceL }} --bindir=/usr/lib/gimp/2.0/plug-ins
+        run: ./configure ${{ matrix.choiceL }} --bindir=/usr/lib/gimp/3.0/plug-ins
       - name: Make fourier plugin
         run: make
       - name: Strip Debug Symbols
@@ -50,9 +50,9 @@ jobs:
       max-parallel: 2
       matrix:
         include: [
-          {msystem: MINGW32, toolchain: mingw-w64-i686, version: x32, gimp: "gimp", gimptool: "gimptool-2.0" },
-          {msystem: MINGW64, toolchain: mingw-w64-x86_64, version: x64, gimp: "gimp", gimptool: "gimptool-2.0" },
           {msystem: MINGW64, toolchain: mingw-w64-x86_64, version: x64, gimp: "gimp3", gimptool: "gimptool-2.99" },
+          {msystem: UCRT64, toolchain: mingw-w64-ucrt-x86_64, version: x64, gimp: "gimp3", gimptool: "gimptool-2.99" },
+          {msystem: CLANG64, toolchain: mingw-w64-clang-x86_64, version: x64, gimp: "gimp3", gimptool: "gimptool-2.99" },
         ]
     runs-on: windows-latest
     defaults:
@@ -69,7 +69,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build plugin
       shell: msys2 {0}

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
-# Makefile.am - Top level automakefile for fourier
+# Makefile.am - Top level automakefile for gimp3-fourier-plugin
 
 # The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
 # Otherwise autoreconf misparses the line.
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
-AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${PKG_CFLAGS}
+AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${GTK_CFLAGS} ${PKG_CFLAGS}
 
 
 bin_PROGRAMS = fourier
@@ -11,21 +11,20 @@ bindir = $(GIMP_BINDIR)/plug-ins
 
 fourier_SOURCES = fourier.c
 fourier.$(OBJEXT): fourier-config.h
-fourier_LDADD = ${LIBS} ${PKG_LIBS}
+fourier_LDADD = ${LIBS} ${GTK_LIBS} ${PKG_LIBS}
 
 fourierdocsdir = ${datarootdir}/gimp-fourier-plugin
 fourierdocs_DATA = LICENSE README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
-	README.md README.Moire			\
+	bootstrap.sh README.md README.Moire	\
 	debian/changelog debian/compat		\
 	debian/control debian/copyright		\
 	debian/fourier-docs.docs debian/rules	\
 	debian/source/format			\
-	rpm/gimp-fourier-plugin.spec.in		\
-	rpm/gimp-fourier-plugin.spec
+	rpm/gimp3-fourier-plugin.spec.in
 nodist_EXTRA_DATA = .git .github
-DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
+DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules, --disable-fourier_dialog
 
 strip:
 	$(STRIP) ${builddir}/fourier
@@ -43,7 +42,7 @@ deb:
 
 
 # NOTE: To install/uninstall fourier in the correct directory we need to use:
-# ./configure --bindir=/usr/lib/gimp/2.0/plug-ins/fourier
+# ./configure --bindir=/usr/lib/gimp/3.0/plug-ins/fourier
 # make
 # make strip
 # sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 # Makefile.am - Top level automakefile for gimp3-fourier-plugin
 
+SUBDIRS = . po
+
 # The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
 # Otherwise autoreconf misparses the line.
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
@@ -7,13 +9,15 @@ AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${GTK_CFLAGS} ${PKG_CFLAGS}
 
 
 bin_PROGRAMS = fourier
-bindir = $(GIMP_BINDIR)/plug-ins
+# 'make distcheck' can't write to ${GIMP_LIBDIR}/plug-ins/ because of
+# directory permissions, therefore don't install fourier unless you are root
+@SNIPPET1@
 
 fourier_SOURCES = fourier.c
 fourier.$(OBJEXT): fourier-config.h
 fourier_LDADD = ${LIBS} ${GTK_LIBS} ${PKG_LIBS}
 
-fourierdocsdir = ${datarootdir}/gimp-fourier-plugin
+fourierdocsdir = ${datarootdir}/gimp3-plugin-fourier
 fourierdocs_DATA = LICENSE README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
@@ -22,9 +26,9 @@ EXTRA_DIST = LICENSE Makefile.gimptool		\
 	debian/control debian/copyright		\
 	debian/fourier-docs.docs debian/rules	\
 	debian/source/format			\
-	rpm/gimp3-fourier-plugin.spec.in
+	rpm/gimp3-plugin-fourier.spec.in
 nodist_EXTRA_DATA = .git .github
-DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules, --disable-fourier_dialog
+DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules --disable-fourier_dialog
 
 strip:
 	$(STRIP) ${builddir}/fourier
@@ -40,9 +44,3 @@ deb:
 	dpkg-buildpackage -b -rfakeroot -us -uc
 	dpkg-buildpackage -rfakeroot -Tclean
 
-
-# NOTE: To install/uninstall fourier in the correct directory we need to use:
-# ./configure --bindir=/usr/lib/gimp/3.0/plug-ins/fourier
-# make
-# make strip
-# sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,10 @@ AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PATH_PROG([STRIP],[strip],[:])
 AC_PATH_PROG([GIMPTOOL],[gimptool-3.0],[:])
+AC_PATH_PROG([MSGFMT],[msgfmt],[:])
+AC_PATH_PROG([MSGINIT],[msginit],[:])
+AC_PATH_PROG([MSGMERGE],[msgmerge],[:])
+AC_PATH_PROG([XGETTEXT],[xgettext],[:])
 AM_CONFIG_HEADER(fourier-config.h)
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -71,7 +75,7 @@ CPPFLAGS="${CPPFLAGS} AS_ESCAPE([-I${top_builddir}]) AS_ESCAPE([-I${top_srcdir}]
 # Check for libraries.
 # NOTE: Some distros don't have /usr/local included in the /etc/ld.so PATH,
 # so, PKG_CHECK_MODULES may not find libraries you compile into /usr/local,
-# therefore use AC_CHECK_HEADERS, AC_SEARCH_LIBS, AC_CHECK_FUNC for backup.
+# therefore use AC_SEARCH_LIBS, AC_CHECK_FUNC for backup.
 #
 # NOTE: some older scripts have defective SEARCH, so we do CHECK if failed.
 
@@ -79,8 +83,7 @@ CPPFLAGS="${CPPFLAGS} AS_ESCAPE([-I${top_builddir}]) AS_ESCAPE([-I${top_srcdir}]
 have_libm=maybe
 AC_CHECK_HEADER([math.h],
   AC_SEARCH_LIBS([cos],[m],[have_libm=yes],
-    AC_CHECK_LIB([m],[cos],[have_libm=yes],
-      AC_CHECK_FUNC([cos],[have_libm=yes]))))
+    AC_CHECK_FUNC([cos],[have_libm=yes])))
 if test x"${have_libm}" != xyes; then
     AC_MSG_FAILURE([ERROR: Please install the Math library and math.h],[1])
 fi
@@ -91,11 +94,27 @@ PKG_CHECK_MODULES([FFTW],[fftw3 >= 3.0],[have_libfftw=yes pkg_cflags="${FFTW_CFL
 if test x"${have_libfftw}" != xyes; then
   AC_CHECK_HEADER([fftw3.h],
     AC_SEARCH_LIBS([fftw_plan_dft_r2c_2d],[fftw3],[have_libfftw=yes],
-      AC_CHECK_LIB([fftw3],[fftw_plan_dft_r2c_2d],[have_libfftw=yes],
-        AC_CHECK_FUNC([fftw_plan_dft_r2c_2d],[have_libfftw=yes]))))
+      AC_CHECK_FUNC([fftw_plan_dft_r2c_2d],[have_libfftw=yes])))
 fi
 if test x"${have_libfftw}" != xyes; then
    AC_MSG_FAILURE([ERROR: Please install the developer version of fftw3 library.],[1])
+fi
+
+# Avoid being locked to a particular gettext verion, use what's available.
+have_gettext=no
+AC_CHECK_HEADERS([intl.h],[have_gettext=yes])
+AC_CHECK_FUNC([gettext],[have_gettext=yes],[have_gettext=no])
+AC_CHECK_FUNC([bind_textdomain_codeset],,[have_gettext=no])
+AC_CHECK_FUNC([textdomain],,[have_gettext=no])
+if test x"${have_gettext}" = xno; then
+	AC_SEARCH_LIBS([intl],[have_gettext=yes],[
+	AC_MSG_ERROR([ERROR: gettext() required! Please install libintl or GETTEXT Packages.])])
+fi
+GETTEXT_PACKAGE=gimp30-fourier
+AC_SUBST(GETTEXT_PACKAGE)
+AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [The gettext translation domain.])
+if test x"${have_gettext}" = xyes; then
+  AC_DEFINE([HAVE_GETTEXT],1,[Enable use of local languages])
 fi
 
 # GIMP3 runs on GTK3 (not GTK), so we need these
@@ -149,13 +168,16 @@ AC_DEFINE([FOURIER_MINOR_VERSION],["fourier_minor_version"],[gimp-fourier-plugin
 AC_SUBST([FOURIER_MAJOR_VERSION],[fourier_major_version])
 AC_SUBST([FOURIER_MINOR_VERSION],[fourier_minor_version])
 AC_SUBST([FOURIER_VERSION],[fourier_version])
+AC_SUBST([FOURIER_PACKAGE_NAME],[fourier_package_name])
+AC_SUBST([FOURIER_EMAIL],[fourier_package_email])
 AC_SUBST([CPPFLAGS],["$CPPFLAGS"])
 AC_SUBST([PKG_CFLAGS],["$pkg_cflags"])
 AC_SUBST([PKG_LIBS],["$pkg_libs"])
 AC_SUBST([HOST],["$host"])
 
 # Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
-GIMP_GIMPLIBDIR=`$PKG_CONFIG --variable=gimplibdir gimp-3.0`
+GIMP_GIMPLIBDIR=`${PKG_CONFIG} --variable=gimplibdir gimp-3.0`
+AC_SUBST(GIMP_GIMPLIBDIR)
 # Seems that gimp does not follow libdir of the distro, so just replacing prefix
 # GIMP_LIBDIR=`$PKG_CONFIG --variable=libdir gimp-3.0`
 # GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_LIBDIR}
@@ -164,6 +186,17 @@ GIMP_PREFIX=`$PKG_CONFIG --variable=exec_prefix gimp-3.0`
 GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_PREFIX}
 GIMP_BINDIR=\${exec_prefix}"$GIMP_RELATIVE"
 AC_SUBST(GIMP_BINDIR)
+
+dnl Do this here since automake can't process 'if/else/endif in Makefile.am
+SNIPPET1='
+ifeq ($(shell id -u),0)
+  bindir = $(GIMP_GIMPLIBDIR)/plug-ins/fourier
+else
+  bindir = $(libdir)/gimp/3.0/plug-ins/fourier
+endif
+'
+AC_SUBST([SNIPPET1])
+AM_SUBST_NOTMAKE([SNIPPET1])
 
 #--------------------------------------------------------------------------
 # Put ifndef wrapper on fourier-config.h so we don't call it repeatedly.
@@ -176,7 +209,8 @@ AH_BOTTOM([
 #--------------------------------------------------------------------------
 AC_CONFIG_FILES([
 Makefile
-rpm/gimp3-fourier-plugin.spec
+po/Makefile
+rpm/gimp3-plugin-fourier.spec
 ])
 AC_OUTPUT
 AC_MSG_NOTICE([
@@ -186,6 +220,8 @@ Configuration:
   Source code location	${srcdir}
   Build code location	${builddir}
   fourier bindir	${GIMP_BINDIR}
+  Use locale languages	${have_gettext}
+  fourier locale dir	${localedir}
   docs root dir		${datarootdir}
   Compiler		${CC}
   cppflag		${CPPFLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl Process this file with "autoreconf -i;automake" to produce a configure scrip
 
 # Copyright (C) 2022 by Joe Da Silva
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.71])
 #--------------------------------------------------------------------------
 # Setup variables before running AC_INIT()
 #
@@ -19,14 +19,16 @@ AC_PREREQ([2.68])
 #   fourier_major_version += 1;
 #   fourier_minor_version = 0;
 #
-m4_define([fourier_major_version], [0.4])
-m4_define([fourier_minor_version], [5])
+m4_define([fourier_major_version], [0])
+m4_define([fourier_minor_version], [0])
 m4_define([fourier_version],[fourier_major_version.fourier_minor_version])
-m4_define([fourier_package_name], [gimp-plugin-fourier])
+m4_define([fourier_package_name], [gimp3-plugin-fourier])
+m4_define([fourier_package_home], [https://www.lprp.fr/gimp_plugin_en/])
+m4_define([fourier_package_email], [https://github.com/rpeyron/plugin-gimp-fourier/issues])
 
 #--------------------------------------------------------------------------
-AC_INIT([fourier],[fourier_version],[https://github.com/rpeyron/plugin-gimp-fourier/issues],
-	[fourier_package_name],[https://www.lprp.fr/gimp_plugin_en/])
+AC_INIT([fourier],[fourier_version],[fourier_package_email],
+	[fourier_package_name],[fourier_package_home])
 # old registry location was: http://registry.gimp.org/node/19596
 #--------------------------------------------------------------------------
 AC_CONFIG_SRCDIR([fourier.c])
@@ -51,7 +53,7 @@ AC_PROG_SED
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PATH_PROG([STRIP],[strip],[:])
-AC_PATH_PROG([GIMPTOOL],[gimptool-2.0],[:])
+AC_PATH_PROG([GIMPTOOL],[gimptool-3.0],[:])
 AM_CONFIG_HEADER(fourier-config.h)
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -96,17 +98,29 @@ if test x"${have_libfftw}" != xyes; then
    AC_MSG_FAILURE([ERROR: Please install the developer version of fftw3 library.],[1])
 fi
 
+# GIMP3 runs on GTK3 (not GTK), so we need these
+GTK_CFLAGS=
+GTK_LIBS=
+have_libgtk=no
+PKG_CHECK_MODULES([GTK],[gtk+-3.0],[have_libgtk=yes])
+if test x"${have_libgtk}" != xyes; then
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgtk+3.],[1])
+fi
+AC_SUBST(GTK_CFLAGS)
+AC_SUBST(GTK_LIBS)
+
 # Check for libgimp/gimp.h include file and libgimp library. LGPL
 have_libgimp=no
-PKG_CHECK_MODULES([GIMP],[gimp-2.0],[have_libgimp=yes pkg_cflags="${pkg_cflags} ${GIMP_CFLAGS}" pkg_libs="${pkg_libs} ${GIMP_LIBS}"],[have_libgimp=no])
+PKG_CHECK_MODULES([GIMP],[gimp-3.0 gimpui-3.0],[have_libgimp=yes pkg_cflags="${pkg_cflags} ${GIMP_CFLAGS}" pkg_libs="${pkg_libs} ${GIMP_LIBS}"],[have_libgimp=no])
+# This was for gimp2
+#if test x"${have_libgimp}" != xyes; then
+#  AC_CHECK_HEADER([gimp.h],
+#    AC_SEARCH_LIBS([gimp_install_procedure],[gimp],[have_libgimp=yes],
+#      AC_CHECK_LIB([gimp],[gimp_install_procedure],[have_libgimp=yes],
+#        AC_CHECK_FUNC([gimp_install_procedure],[have_libgimp=yes]))))
+#fi
 if test x"${have_libgimp}" != xyes; then
-  AC_CHECK_HEADER([gimp.h],
-    AC_SEARCH_LIBS([gimp_install_procedure],[gimp],[have_libgimp=yes],
-      AC_CHECK_LIB([gimp],[gimp_install_procedure],[have_libgimp=yes],
-        AC_CHECK_FUNC([gimp_install_procedure],[have_libgimp=yes]))))
-fi
-if test x"${have_libgimp}" != xyes; then
-    AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp.],[1])
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp3.],[1])
 fi
 
 case "$build_os" in
@@ -114,6 +128,16 @@ case "$build_os" in
 esac
 
 AM_CONDITIONAL([HAVEGIMPTOOL],[test "${GIMPTOOL}"x != x])
+
+#--------------------------------------------------------------------------
+# Enable fourier dialog mode
+AC_ARG_ENABLE([fourier_dialog],
+  [AS_HELP_STRING([--enable-fourier_dialog],
+    [Enable fourier_dialog mode @<:@default=no@:>@])],
+  [],[enable_fourier_dialog=no])
+if test "x$enable_fourier_dialog" = xyes || test "x$enable_fourier_dialog" = xtrue ; then
+  AC_DEFINE([FOURIER_USE_DIALOG],1,[Define if using GIMP-3.0 style dialog.])
+fi
 
 #--------------------------------------------------------------------------
 # Pass variables to fourier-config.h
@@ -131,12 +155,12 @@ AC_SUBST([PKG_LIBS],["$pkg_libs"])
 AC_SUBST([HOST],["$host"])
 
 # Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
-GIMP_GIMPLIBDIR=`$PKG_CONFIG --variable=gimplibdir gimp-2.0`
+GIMP_GIMPLIBDIR=`$PKG_CONFIG --variable=gimplibdir gimp-3.0`
 # Seems that gimp does not follow libdir of the distro, so just replacing prefix
-# GIMP_LIBDIR=`$PKG_CONFIG --variable=libdir gimp-2.0`
+# GIMP_LIBDIR=`$PKG_CONFIG --variable=libdir gimp-3.0`
 # GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_LIBDIR}
 # GIMP_BINDIR="$libdir$GIMP_RELATIVE"
-GIMP_PREFIX=`$PKG_CONFIG --variable=exec_prefix gimp-2.0`
+GIMP_PREFIX=`$PKG_CONFIG --variable=exec_prefix gimp-3.0`
 GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_PREFIX}
 GIMP_BINDIR=\${exec_prefix}"$GIMP_RELATIVE"
 AC_SUBST(GIMP_BINDIR)
@@ -152,7 +176,7 @@ AH_BOTTOM([
 #--------------------------------------------------------------------------
 AC_CONFIG_FILES([
 Makefile
-rpm/gimp-fourier-plugin.spec
+rpm/gimp3-fourier-plugin.spec
 ])
 AC_OUTPUT
 AC_MSG_NOTICE([
@@ -167,6 +191,8 @@ Configuration:
   cppflag		${CPPFLAGS}
   pkg_cflag		${PKG_CFLAGS}
   pkg_libs		${PKG_LIBS}
+  GTK_CFLAGS		${GTK_CFLAGS}
+  GTK_LIBS		${GTK_LIBS}
   CFLAGS		${CFLAGS}
   LIBS			${LIBS}
 ])

--- a/debian/control
+++ b/debian/control
@@ -1,19 +1,19 @@
-Source: gimp-plugin-fourier
+Source: gimp3-plugin-fourier
 Section: graphics
 Priority: optional
 Maintainer: Rémi Peyronnet <remi+fourier@via.ecp.fr>
-Build-Depends: autotools-dev, libfftw3-dev, libgimp2.0-dev
+Build-Depends: autotools-dev, libfftw3-dev, libgimp-3.0-dev
 Standards-Version: 4.5.1
 Homepage: https://www.lprp.fr/gimp_plugin_en/
-#Vcs-Browser: https://salsa.debian.org/debian/fourier
-#Vcs-Git: https://salsa.debian.org/debian/fourier.git
+#Vcs-Browser: https://salsa.debian.org/debian/fourier3
+#Vcs-Git: https://salsa.debian.org/debian/fourier3.git
 Rules-Requires-Root: no
 
-Package: gimp-plugin-fourier
+Package: gimp3-plugin-fourier
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: GIMP Plugin to do forward and reverse Fourier Transform
-  This GIMP plugin will add 2 items in the filters menu 
+  This GIMP plugin will add two items in the filters menu
   Filters/Generic/FFT Forward and Filters/Generic/FFT Inverse
   It does a direct and reverse Fourier Transform.
   It allows you to work in the frequency domain.

--- a/fourier.c
+++ b/fourier.c
@@ -294,9 +294,19 @@ void process_fft_inverse(guchar *src_pixels, guchar *dst_pixels, gint sel_width,
 
 #include <libgimp/gimpui.h>
 
-#define GETTEXT_PACKAGE "glib"
-
-#include "libgimp/stdplugins-intl.h"
+#ifdef HAVE_GETTEXT
+#include <libintl.h>
+#define _(String) gettext (String)
+#ifdef gettext_noop
+#    define N_(String) gettext_noop (String)
+#else
+#    define N_(String) (String)
+#endif
+#else
+/* No i18n for now */
+#define _(x) x
+#define N_(x) x
+#endif
 
 #define FOURIER_USE_DIALOG  false
 
@@ -341,7 +351,7 @@ static gboolean plugin_dialog(GimpProcedure *procedure,
 G_DEFINE_TYPE(Fourier, fourier, GIMP_TYPE_PLUG_IN)
 
 GIMP_MAIN(FOURIER_TYPE)
-DEFINE_STD_SET_I18N
+//DEFINE_STD_SET_I18N use fourier po files
 
 typedef enum
 {
@@ -356,7 +366,7 @@ fourier_class_init(FourierClass *klass)
 
   plug_in_class->query_procedures = fourier_query_procedures;
   plug_in_class->create_procedure = fourier_create_procedure;
-  plug_in_class->set_i18n = STD_SET_I18N;
+  //plug_in_class->set_i18n = STD_SET_I18N; use fourier po files
 }
 
 static void
@@ -397,6 +407,16 @@ fourier_create_procedure(GimpPlugIn *plug_in,
     gimp_procedure_set_sensitivity_mask(procedure,
                                         GIMP_PROCEDURE_SENSITIVE_DRAWABLE);
 
+#ifdef HAVE_GETTEXT
+    /* Initialize i18n support */
+    setlocale (LC_ALL, "");
+    bindtextdomain (GETTEXT_PACKAGE, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+    bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+#endif
+    textdomain (GETTEXT_PACKAGE);
+#endif
+
     gimp_procedure_set_menu_label(procedure, _("_Fourier..."));
     gimp_procedure_add_menu_path(procedure, PLUG_IN_MENU_LOCATION);
 
@@ -433,6 +453,16 @@ fourier_create_procedure(GimpPlugIn *plug_in,
     gimp_procedure_set_image_types(procedure, "RGB");
     gimp_procedure_set_sensitivity_mask(procedure,
                                         GIMP_PROCEDURE_SENSITIVE_DRAWABLE);
+
+#ifdef HAVE_GETTEXT
+    /* Initialize i18n support */
+    setlocale (LC_ALL, "");
+    bindtextdomain (GETTEXT_PACKAGE, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+    bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+#endif
+    textdomain (GETTEXT_PACKAGE);
+#endif
 
     gimp_procedure_set_menu_label(procedure, _(PLUG_IN_DIR_MENU_LABEL));
     gimp_procedure_add_menu_path(procedure, PLUG_IN_MENU_LOCATION);
@@ -605,6 +635,16 @@ fourier_run(GimpProcedure *procedure,
   GimpDrawable *drawable;
   gboolean inverse = FALSE;
   gboolean new_layer = FALSE;
+
+#ifdef HAVE_GETTEXT
+  /* Initialize i18n support */
+  setlocale (LC_ALL, "");
+  bindtextdomain (GETTEXT_PACKAGE, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+  bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+#endif
+  textdomain (GETTEXT_PACKAGE);
+#endif
 
   gegl_init(NULL, NULL);
 

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -1,0 +1,56 @@
+LANGUAGES = fr
+PO_FILES = fr.po
+
+# This information is here to help translators create/update (pot/po files):
+#
+# To create a new pot file, you need to cd into this po directory first:
+#   cd po
+#   del gimp30-fourier.pot
+#   make update-pot
+#
+# To update existing po files you need to cd into po directory and then do:
+#   cd po
+#   make update-po
+#
+
+.PHONY: all install uninstall clean $(LANGUAGES)
+.PHONY: update-po update-pot
+
+all: $(LANGUAGES)
+
+$(LANGUAGES):
+	if [[ -e $(srcdir)/$@.po ]]; \
+	then $(MSGFMT) -c -v -o $(builddir)/$@.mo $(srcdir)/$@.po; \
+	else $(MSGFMT) -c -v -o $(builddir)/$@.mo $(builddir)/$@.po; \
+	fi
+
+update-po: $(PO_FILES)
+
+$(PO_FILES): $(GETTEXT_PACKAGE).pot
+	if [[ -e $(srcdir)/$@ ]]; \
+	then $(MSGMERGE) -U $(srcdir)/$@ $^; \
+	else $(MSGFMT) -l $(subst .po,,$@) -o $(builddir)/$@ -i $^; \
+	fi
+
+install-data-local: $(LANGUAGES)
+	for L in $(LANGUAGES); \
+	do $(MKDIR_P) -p "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES"; \
+	install -v -m 0644 $(builddir)/$$L.mo "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES/$(GETTEXT_PACKAGE).mo"; \
+	done
+
+uninstall-local: $(LANGUAGES)
+	for L in $(LANGUAGES); \
+	do rm -vf "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES/$(GETTEXT_PACKAGE).mo"; \
+	done
+
+clean-local:
+	rm -f *.po~ *.mo *.mo~
+
+update-pot: $(GETTEXT_PACKAGE).pot
+
+$(GETTEXT_PACKAGE).pot:
+	$(XGETTEXT) -k_ -k_\" -d $(GETTEXT_PACKAGE) -o $@ \
+	--package-version=$(FOURIER_VERSION) --msgid-bugs-address=$(FOURIER_EMAIL) \
+	../*.c
+
+EXTRA_DIST = $(PO_FILES) $(GETTEXT_PACKAGE).pot

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,55 @@
+# gimp3-fourier-plugin
+# Copyright (C) 2024
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gimp30-fourier-plugin\n"
+"Report-Msgid-Bugs-To: https://github.com/rpeyron/plugin-gimp-fourier/issues\n"
+"POT-Creation-Date: 2024-05-21 15:18-0700\n"
+"PO-Revision-Date: 2024-05-21 00:00+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../fourier.c:420
+msgid "_Fourier..."
+msgstr ""
+
+#: ../fourier.c:433
+msgid "Mode"
+msgstr ""
+
+#: ../fourier.c:434
+msgid "Mode { Foward (0), Inversed (1) }"
+msgstr ""
+
+#: ../fourier.c:439
+msgid "Create _new layer"
+msgstr ""
+
+#: ../fourier.c:440
+msgid "Create a new layer"
+msgstr ""
+
+#: ../fourier.c:656
+#, c-format
+msgid "Procedure '%s' only works with one drawable."
+msgstr ""
+
+#: ../fourier.c:710
+msgid "Fourier"
+msgstr ""
+
+#: ../fourier.c:719
+msgid "_Forward"
+msgstr ""
+
+#: ../fourier.c:720
+msgid "_Inverse"
+msgstr ""

--- a/po/gimp30-fourier.pot
+++ b/po/gimp30-fourier.pot
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/rpeyron/plugin-gimp-fourier/issues\n"
+"POT-Creation-Date: 2024-05-21 15:53-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../fourier.c:420
+msgid "_Fourier..."
+msgstr ""
+
+#: ../fourier.c:433
+msgid "Mode"
+msgstr ""
+
+#: ../fourier.c:434
+msgid "Mode { Foward (0), Inversed (1) }"
+msgstr ""
+
+#: ../fourier.c:439
+msgid "Create _new layer"
+msgstr ""
+
+#: ../fourier.c:440
+msgid "Create a new layer"
+msgstr ""
+
+#: ../fourier.c:656
+#, c-format
+msgid "Procedure '%s' only works with one drawable."
+msgstr ""
+
+#: ../fourier.c:710
+msgid "Fourier"
+msgstr ""
+
+#: ../fourier.c:719
+msgid "_Forward"
+msgstr ""
+
+#: ../fourier.c:720
+msgid "_Inverse"
+msgstr ""

--- a/rpm/gimp3-fourier-plugin.spec.in
+++ b/rpm/gimp3-fourier-plugin.spec.in
@@ -1,26 +1,27 @@
 #
-# spec file for package gimp-fourier-plugin
+# spec file for package gimp3-plugin-fourier
 #
 # Copyright (c) 2011 Kyrill Detinov (Version 0.4.1)
 # This file and all modifications and additions to the pristine
 # package are under the same license as the package itself.
 # Modified for autoconf style build by Joe Da Silva (v0.4.3)
 #
-Name:		gimp-plugin-fourier
+Name:		gimp3-plugin-fourier
 Version:	@FOURIER_VERSION@
 Release:	0
 Summary:	Do direct and reverse Fourier Transforms on your image
 License:	GPLv3+
 URL:		https://www.lprp.fr/gimp_plugin_en/
 Group:          Productivity/Graphics/Bitmap Editors
-Source0:	https://github.com/rpeyron/plugin-gimp-fourier/releases/download/v%{version}/gimp-plugin-fourier-%{version}.tar.gz
+Source0:	https://github.com/rpeyron/plugin-gimp-fourier/releases/download/v%{version}/gimp3-plugin-fourier-%{version}.tar.gz
 BuildRequires:	autoconf
 BuildRequires:	automake
 BuildRequires:	gcc
 BuildRequires:	make
 BuildRequires:  pkgconfig(fftw3)
-BuildRequires:  pkgconfig(gimp-2.0)
-Requires:       gimp
+BuildRequires:  gtk+3-devel
+BuildRequires:  pkgconfig(gimp-3.0)
+Requires:       gimp-3.0
 Requires:       libfftw3
 
 %description
@@ -36,13 +37,13 @@ Useful in fixing moire patterns or fixing some regular banding noise.
 %build
 #%autoreconf -i
 #%automake
-%configure --bindir=%{_libdir}/gimp/2.0/plug-ins
+%configure --bindir=%{_libdir}/gimp/3.0/plug-ins
 %make_build
 
 %install
-# We can’t use “gimptool-2.0 install-bin” to install into plug-ins directory.
-# We therefore don’t need gimptool-2.0 at all.
-%make_install bindir=%{_libdir}/gimp/2.0/plug-ins datadir=%{_datadir}
+# We can’t use “gimptool-3.0 install-bin” to install into plug-ins directory.
+# We therefore don’t need gimptool-3.0 at all.
+%make_install bindir=%{_libdir}/gimp/3.0/plug-ins datadir=%{_datadir}
 
 # Upstream provides no tests.
 
@@ -50,6 +51,6 @@ Useful in fixing moire patterns or fixing some regular banding noise.
 %doc %{_datadir}/gimp-fourier-plugin/LICENSE
 %doc %{_datadir}/gimp-fourier-plugin/README.md
 %doc %{_datadir}/gimp-fourier-plugin/README.Moire
-%{_libdir}/gimp/2.0/plug-ins/fourier
+%{_libdir}/gimp/3.0/plug-ins/fourier
 
 %changelog

--- a/rpm/gimp3-plugin-fourier.spec.in
+++ b/rpm/gimp3-plugin-fourier.spec.in
@@ -4,9 +4,12 @@
 # Copyright (c) 2011 Kyrill Detinov (Version 0.4.1)
 # This file and all modifications and additions to the pristine
 # package are under the same license as the package itself.
-# Modified for autoconf style build by Joe Da Silva (v0.4.3)
+# Modified for autoconf style build by Joe Da Silva
 #
-Name:		gimp3-plugin-fourier
+%define         moname    gimp30-fourier
+%define         plugindir %{_libdir}/gimp/3.0/plug-ins/fourier
+
+Name:		@FOURIER_PACKAGE_NAME@
 Version:	@FOURIER_VERSION@
 Release:	0
 Summary:	Do direct and reverse Fourier Transforms on your image
@@ -19,14 +22,14 @@ BuildRequires:	automake
 BuildRequires:	gcc
 BuildRequires:	make
 BuildRequires:  pkgconfig(fftw3)
-BuildRequires:  gtk+3-devel
+BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(gimp-3.0)
-Requires:       gimp-3.0
-Requires:       libfftw3
+#Requires:       gimp-3.0
+Requires:       lib64fftw3
 
 %description
-GIMP Plugin to do forward and reverse Fourier Transform. The major advantage
-of this plugin is to be able to work with the transformed image inside GIMP.
+GIMP3 Plugin to do forward and reverse Fourier Transform. The major advantage
+of this plugin is to be able to work with the transformed image inside GIMP3.
 You can draw or apply filters in fourier space and get the modified image
 with an inverse fourier transform.
 Useful in fixing moire patterns or fixing some regular banding noise.
@@ -35,22 +38,22 @@ Useful in fixing moire patterns or fixing some regular banding noise.
 %setup ‑q
 
 %build
-#%autoreconf -i
-#%automake
-%configure --bindir=%{_libdir}/gimp/3.0/plug-ins
+autoreconf -i
+automake --add-missing
+%configure
 %make_build
 
 %install
-# We can’t use “gimptool-3.0 install-bin” to install into plug-ins directory.
-# We therefore don’t need gimptool-3.0 at all.
-%make_install bindir=%{_libdir}/gimp/3.0/plug-ins datadir=%{_datadir}
+%make_install INSTALLDIR="%{buildroot}/%{plugindir}" \
+      LOCALEDIR="%{buildroot}/%{_datadir}/locale"
+%find_lang %{moname}
 
 # Upstream provides no tests.
 
-%files
-%doc %{_datadir}/gimp-fourier-plugin/LICENSE
-%doc %{_datadir}/gimp-fourier-plugin/README.md
-%doc %{_datadir}/gimp-fourier-plugin/README.Moire
-%{_libdir}/gimp/3.0/plug-ins/fourier
+%files -f %{moname}.lang
+%doc %{_datadir}/gimp3-plugin-fourier/LICENSE
+%doc %{_datadir}/gimp3-plugin-fourier/README.md
+%doc %{_datadir}/gimp3-plugin-fourier/README.Moire
+%{plugindir}/fourier
 
 %changelog


### PR DESCRIPTION
Changed configure/make files so that they use GTK3 and GIMP3.
Also updated main.yml, debian/control, and rpm spec file to do similar.

I wasn't sure what FOURIER_DIALOG was, but added it to ./configure --help
While trying to compile fourier.c, I ran into similar problem seen on fix-ca.c
so I duplicated the po/Makefile.am setup from fix-ca into fourier, and now fourier builds
and also installs okay.
NOTE: gimp3 complained about fourier not being in it's own folder, so it seems we need to also add a subfolder in plugin directory
```
autoreconf -i
automake
./configure (options?)
make
sudo make install
```
exe now found in /usr/lib64/gimp/3.0/plugin/fourier/fourier, and the po files go into local subfolders.
Distro maintainers will probably want to run `./configure --prefix=/usr` so that the po files go into /usr/share/locale instead of /usr/local/share/locale

gimptool is still named gimptool-2.99 but it isn't building anything for gimp-3.0 yet.
I've noticed that fix-ca doesn't include -lm when building, and I think you have the added problem of getting -lfftw as well

NOTE: configure.ac=SNIPPET1 is pointing Makefile.am to gimp/3.0/ which is what gimp-2.99.99.19+ at RC1 is at now. I did not try fourier at gimp-2.99.18