### PR TITLE
Updated configure/make to build GIMP2 or GIMP3 versions of fourier.c

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           autoreconf -i
           automake
       - name: Choose configure
-        run: ./configure ${{ matrix.choiceL }} --bindir=/usr/lib/gimp/2.0/plug-ins
+        run: ./configure ${{ matrix.choiceL }}
       - name: Make fourier plugin
         run: make
       - name: Strip Debug Symbols
@@ -69,7 +69,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build plugin
       shell: msys2 {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push,pull_request]
 
 jobs:
-  linux:
+  gimp2_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,8 +35,10 @@ jobs:
           sudo make install
           sudo make uninstall
       - name: Build deb package
+        if: matrix.choiceL == '--enable-silent-rules'
         run: make clean && ./configure && make deb && cp ../gimp-plugin-fourier_* .
       - name: Build dist
+        if: matrix.choiceL == '--enable-silent-rules'
         run: ./configure && make dist
       - uses: actions/upload-artifact@v2
         with:
@@ -44,7 +46,60 @@ jobs:
           path: |
             gimp-plugin-fourier_*
             gimp-plugin-fourier-*.tar.gz
-  win:
+  gimp2_win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include: [
+          {msystem: MINGW32, toolchain: mingw-w64-i686, version: x32 },
+          {msystem: MINGW64, toolchain: mingw-w64-x86_64, version: x64 },
+          {msystem: UCRT64, toolchain: mingw-w64-ucrt-x86_64, version: x64 },
+          {msystem: CLANG64, toolchain: mingw-w64-clang-x86_64, version: x64 },
+        ]
+    name: gimp2_${{ matrix.msystem }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: autotools base-devel git ${{ matrix.toolchain }}-toolchain ${{ matrix.toolchain }}-gimp ${{ matrix.toolchain }}-fftw
+      - name: Create configure
+        run: |
+          autoreconf -i
+          automake
+      - name: run ./configure
+        run: ./configure
+      - name: Make gimp-plugin-fourier
+        run: make
+  gimp3_linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        choiceL: [--disable-silent-rules, --enable-silent-rules]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create configure
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install autoconf automake libtool gcc libfftw3-dev libgimp-3.0-dev
+          autoreconf -i
+          automake
+      - name: Choose configure
+        run: ./configure ${{ matrix.choiceL }} --enable-gimp3-fourier
+      - name: Make fourier3 plugin
+        run: make
+      - name: Strip Debug Symbols
+        run: make strip
+      - name: Test make install GIMP shared plugin
+        if: matrix.choiceL == '--disable-silent-rules'
+        run: |
+          sudo make install
+          sudo make uninstall
+  gimp3_win:
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         choiceL: [--disable-silent-rules, --enable-silent-rules]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create configure
         run: |
           sudo apt-get update -y
@@ -81,7 +81,7 @@ jobs:
       matrix:
         choiceL: [--disable-silent-rules, --enable-silent-rules]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create configure
         run: |
           sudo apt-get update -y

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,27 +3,26 @@
 # The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
 # Otherwise autoreconf misparses the line.
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
-AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${PKG_CFLAGS}
+AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${GIMP2_CFLAGS} ${GTK2_CFLAGS} ${FFTW_CFLAGS}
 
 
-bin_PROGRAMS = fourier
-bindir = $(GIMP_BINDIR)/plug-ins
+bin2_PROGRAMS = fourier
+bin2dir = $(GIMP2_BINDIR)/plug-ins
 
 fourier_SOURCES = fourier.c
 fourier.$(OBJEXT): fourier-config.h
-fourier_LDADD = ${LIBS} ${PKG_LIBS}
+fourier_LDADD = ${LIBS} ${GIMP2_LIBS} ${GTK2_LIBS} ${FFTW_LIBS}
 
 #avoid line below due to dirs gimp-plugin-fourier vs gimp-fourier-plugin
 #doc_DATA = README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
-	README.md README.Moire			\
+	bootstrap.sh README.md README.Moire	\
 	debian/changelog debian/compat		\
 	debian/control debian/copyright		\
 	debian/fourier-docs.docs debian/rules	\
 	debian/source/format			\
-	rpm/gimp-fourier-plugin.spec.in		\
-	rpm/gimp-fourier-plugin.spec
+	rpm/gimp-fourier-plugin.spec.in
 nodist_EXTRA_DATA = .git .github
 DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
 
@@ -32,10 +31,10 @@ strip:
 
 # These use gimptool to install/uninstall fourier in user directory
 install-user:
-	$(GIMPTOOL) --install-bin ${builddir}/fourier
+	$(GIMPTOOL2) --install-bin ${builddir}/fourier
 
 uninstall-user:
-	$(GIMPTOOL) --uninstall-bin fourier
+	$(GIMPTOOL2) --uninstall-bin fourier
 
 deb:
 	dpkg-buildpackage -b -rfakeroot -us -uc

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,8 @@ fourier_SOURCES = fourier.c
 fourier.$(OBJEXT): fourier-config.h
 fourier_LDADD = ${LIBS} ${PKG_LIBS}
 
-fourierdocsdir = ${datarootdir}/gimp-fourier-plugin
-fourierdocs_DATA = LICENSE README.md README.Moire
+#avoid line below due to dirs gimp-plugin-fourier vs gimp-fourier-plugin
+#doc_DATA = README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
 	README.md README.Moire			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,36 +7,34 @@ SUBDIRS = .
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
 AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${FFTW_CFLAGS}
 
+fourier_SOURCES = fourier.c
+fourier.$(OBJEXT): fourier-config.h
+fourier_LDADD = ${LIBS} ${FFTW_LIBS}
+fourier_CFLAGS =
+GIMPTOOL =
+
 bin2_PROGRAMS =
 bin2dir =
-fourier_SOURCES =
-fourier_LDADD =
-fourier_CFLAGS =
 if MAKEGIMP2
 bin2_PROGRAMS += fourier
 bin2dir += $(GIMP2_BINDIR)/plug-ins
-fourier_SOURCES += fourier.c
-fourier.$(OBJEXT): fourier-config.h
-fourier_LDADD += ${LIBS} ${GIMP2_LIBS} ${GTK2_LIBS} ${FFTW_LIBS}
+fourier_LDADD += ${GIMP2_LIBS} ${GTK2_LIBS}
 fourier_CFLAGS += ${GIMP2_CFLAGS} ${GTK2_CFLAGS} -DMAKE_FOR_GIMP3=0
+GIMPTOOL += ${GIMPTOOL2}
 endif
 
 bin3_PROGRAMS =
 bin3dir =
-fourier3_SOURCES =
-fourier3_LDADD =
-fourier3_CFLAGS =
 if MAKEGIMP3
 SUBDIRS += po
-bin3_PROGRAMS += fourier3
+bin3_PROGRAMS += fourier
 # 'make distcheck' can't write to ${GIMP3_LIBDIR}/plug-ins/fourier because of
-# directory permissions, therefore don't install fourier3 unless you are root
+# directory permissions, therefore don't install fourier unless you are root.
 # bin3dir += $(GIMP3_BINDIR)/plug-ins/fourier
 @SNIPPET1@
-fourier3_SOURCES += fourier.c
-fourier3.$(OBJEXT): fourier-config.h
-fourier3_LDADD += ${LIBS} ${GIMP3_LIBS} ${GTK3_LIBS} ${FFTW_LIBS}
-fourier3_CFLAGS += ${GIMP3_CFLAGS} ${GTK3_CFLAGS} -DMAKE_FOR_GIMP3=1
+fourier_LDADD += ${GIMP3_LIBS} ${GTK3_LIBS}
+fourier_CFLAGS += ${GIMP3_CFLAGS} ${GTK3_CFLAGS} -DMAKE_FOR_GIMP3=1
+GIMPTOOL += ${GIMPTOOL3}
 endif
 
 # Avoid using this line below (Dirs gimp-plugin-fourier vs gimp-fourier-plugin).
@@ -54,29 +52,14 @@ nodist_EXTRA_DATA = .git .github
 DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules --enable-silent-rules --enable-fourier_dialog
 
 strip:
-	if MAKEGIMP2; \
-	then $(STRIP) ${builddir}/fourier; \
-	fi; \
-	if MAKEGIMP3; \
-	then $(STRIP) ${builddir}/fourier3; \
-	fi
+	$(STRIP) ${builddir}/fourier
 
 # These use gimptool to install/uninstall fourier in user directory
 install-user:
-	if MAKEGIMP2; \
-	then $(GIMPTOOL2) --install-bin ${builddir}/fourier; \
-	fi; \
-	if MAKEGIMP3; \
-	then $(GIMPTOOL3) --install-bin ${builddir}/fourier3; \
-	fi
+	$(GIMPTOOL) --install-bin ${builddir}/fourier
 
 uninstall-user:
-	if MAKEGIMP2; \
-	then $(GIMPTOOL2) --uninstall-bin fourier; \
-	fi; \
-	if MAKEGIMP3; \
-	then $(GIMPTOOL3) --uninstall-bin fourier3; \
-	fi
+	$(GIMPTOOL) --uninstall-bin fourier
 
 deb:
 	dpkg-buildpackage -b -rfakeroot -us -uc

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,15 +3,35 @@
 # The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
 # Otherwise autoreconf misparses the line.
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
-AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${GIMP2_CFLAGS} ${GTK2_CFLAGS} ${FFTW_CFLAGS}
+AM_CFLAGS = ${CFLAGS} ${CPPFLAGS} ${FFTW_CFLAGS}
 
-
-bin2_PROGRAMS = fourier
-bin2dir = $(GIMP2_BINDIR)/plug-ins
-
-fourier_SOURCES = fourier.c
+bin2_PROGRAMS =
+bin2dir =
+fourier_SOURCES =
+fourier_LDADD =
+fourier_CFLAGS =
+if MAKEGIMP2
+bin2_PROGRAMS += fourier
+bin2dir += $(GIMP2_BINDIR)/plug-ins
+fourier_SOURCES += fourier.c
 fourier.$(OBJEXT): fourier-config.h
-fourier_LDADD = ${LIBS} ${GIMP2_LIBS} ${GTK2_LIBS} ${FFTW_LIBS}
+fourier_LDADD += ${LIBS} ${GIMP2_LIBS} ${GTK2_LIBS} ${FFTW_LIBS}
+fourier_CFLAGS += ${GIMP2_CFLAGS} ${GTK2_CFLAGS}
+endif
+
+bin3_PROGRAMS =
+bin3dir =
+fourier3_SOURCES =
+fourier3_LDADD =
+fourier3_CFLAGS =
+if MAKEGIMP3
+bin3_PROGRAMS += fourier3
+bin3dir += $(GIMP3_BINDIR)/plug-ins
+fourier3_SOURCES += fourier.c
+fourier3.$(OBJEXT): fourier-config.h
+fourier3_LDADD += ${LIBS} ${GIMP3_LIBS} ${GTK3_LIBS} ${FFTW_LIBS}
+fourier3_CFLAGS += ${GIMP3_CFLAGS} ${GTK3_CFLAGS} -DFOURIER_USE_DIALOG=1
+endif
 
 #avoid line below due to dirs gimp-plugin-fourier vs gimp-fourier-plugin
 #doc_DATA = README.md README.Moire
@@ -22,27 +42,37 @@ EXTRA_DIST = LICENSE Makefile.gimptool		\
 	debian/control debian/copyright		\
 	debian/fourier-docs.docs debian/rules	\
 	debian/source/format			\
-	rpm/gimp-fourier-plugin.spec.in
+	rpm/gimp-fourier-plugin.spec.in		\
+	rpm/gimp3-fourier-plugin.spec.in
 nodist_EXTRA_DATA = .git .github
 DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
 
 strip:
-	$(STRIP) ${builddir}/fourier
+	if MAKEGIMP2; \
+	then $(STRIP) ${builddir}/fourier; \
+	fi; \
+	if MAKEGIMP3; \
+	then $(STRIP) ${builddir}/fourier3; \
+	fi
 
 # These use gimptool to install/uninstall fourier in user directory
 install-user:
-	$(GIMPTOOL2) --install-bin ${builddir}/fourier
+	if MAKEGIMP2; \
+	then $(GIMPTOOL2) --install-bin ${builddir}/fourier; \
+	fi; \
+	if MAKEGIMP3; \
+	then $(GIMPTOOL3) --install-bin ${builddir}/fourier3; \
+	fi
 
 uninstall-user:
-	$(GIMPTOOL2) --uninstall-bin fourier
+	if MAKEGIMP2; \
+	then $(GIMPTOOL2) --uninstall-bin fourier; \
+	fi; \
+	if MAKEGIMP3; \
+	then $(GIMPTOOL3) --uninstall-bin fourier3; \
+	fi
 
 deb:
 	dpkg-buildpackage -b -rfakeroot -us -uc
 	dpkg-buildpackage -rfakeroot -Tclean
 
-
-# NOTE: To install/uninstall fourier in the correct directory we need to use:
-# ./configure --bindir=/usr/lib/gimp/2.0/plug-ins/fourier
-# make
-# make strip
-# sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 # Makefile.am - Top level automakefile for fourier
 
+SUBDIRS = .
+
 # The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
 # Otherwise autoreconf misparses the line.
 ACLOCAL_AMFLAGS=-I m4 ${ACLOCAL_FLAGS}
@@ -16,7 +18,7 @@ bin2dir += $(GIMP2_BINDIR)/plug-ins
 fourier_SOURCES += fourier.c
 fourier.$(OBJEXT): fourier-config.h
 fourier_LDADD += ${LIBS} ${GIMP2_LIBS} ${GTK2_LIBS} ${FFTW_LIBS}
-fourier_CFLAGS += ${GIMP2_CFLAGS} ${GTK2_CFLAGS}
+fourier_CFLAGS += ${GIMP2_CFLAGS} ${GTK2_CFLAGS} -DMAKE_FOR_GIMP3=0
 endif
 
 bin3_PROGRAMS =
@@ -25,15 +27,19 @@ fourier3_SOURCES =
 fourier3_LDADD =
 fourier3_CFLAGS =
 if MAKEGIMP3
+SUBDIRS += po
 bin3_PROGRAMS += fourier3
-bin3dir += $(GIMP3_BINDIR)/plug-ins
+# 'make distcheck' can't write to ${GIMP3_LIBDIR}/plug-ins/fourier because of
+# directory permissions, therefore don't install fourier3 unless you are root
+# bin3dir += $(GIMP3_BINDIR)/plug-ins/fourier
+@SNIPPET1@
 fourier3_SOURCES += fourier.c
 fourier3.$(OBJEXT): fourier-config.h
 fourier3_LDADD += ${LIBS} ${GIMP3_LIBS} ${GTK3_LIBS} ${FFTW_LIBS}
-fourier3_CFLAGS += ${GIMP3_CFLAGS} ${GTK3_CFLAGS} -DFOURIER_USE_DIALOG=1
+fourier3_CFLAGS += ${GIMP3_CFLAGS} ${GTK3_CFLAGS} -DMAKE_FOR_GIMP3=1
 endif
 
-#avoid line below due to dirs gimp-plugin-fourier vs gimp-fourier-plugin
+# Avoid using this line below (Dirs gimp-plugin-fourier vs gimp-fourier-plugin).
 #doc_DATA = README.md README.Moire
 
 EXTRA_DIST = LICENSE Makefile.gimptool		\
@@ -45,7 +51,7 @@ EXTRA_DIST = LICENSE Makefile.gimptool		\
 	rpm/gimp-fourier-plugin.spec.in		\
 	rpm/gimp3-fourier-plugin.spec.in
 nodist_EXTRA_DATA = .git .github
-DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
+DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules --enable-silent-rules --enable-fourier_dialog
 
 strip:
 	if MAKEGIMP2; \

--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,12 @@ m4_define([fourier_major_version], [0.4])
 m4_define([fourier_minor_version], [5])
 m4_define([fourier_version],[fourier_major_version.fourier_minor_version])
 m4_define([fourier_package_name], [gimp-plugin-fourier])
+m4_define([fourier_package_home], [https://www.lprp.fr/gimp_plugin_en/])
+m4_define([fourier_package_email], [https://github.com/rpeyron/plugin-gimp-fourier/issues])
 
 #--------------------------------------------------------------------------
-AC_INIT([fourier],[fourier_version],[https://github.com/rpeyron/plugin-gimp-fourier/issues],
-	[fourier_package_name],[https://www.lprp.fr/gimp_plugin_en/])
+AC_INIT([fourier],[fourier_version],[fourier_package_email],
+	[fourier_package_name],[fourier_package_home])
 # old registry location was: http://registry.gimp.org/node/19596
 #--------------------------------------------------------------------------
 AC_CONFIG_SRCDIR([fourier.c])
@@ -51,7 +53,7 @@ AC_PROG_SED
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PATH_PROG([STRIP],[strip],[:])
-AC_PATH_PROG([GIMPTOOL],[gimptool-2.0],[:])
+AC_PATH_PROG([GIMPTOOL2],[gimptool-2.0],[:])
 AM_CONFIG_HEADER(fourier-config.h)
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -69,7 +71,7 @@ CPPFLAGS="${CPPFLAGS} AS_ESCAPE([-I${top_builddir}]) AS_ESCAPE([-I${top_srcdir}]
 # Check for libraries.
 # NOTE: Some distros don't have /usr/local included in the /etc/ld.so PATH,
 # so, PKG_CHECK_MODULES may not find libraries you compile into /usr/local,
-# therefore use AC_CHECK_HEADERS, AC_SEARCH_LIBS, AC_CHECK_FUNC for backup.
+# therefore use AC_SEARCH_LIBS, AC_CHECK_FUNC for backup.
 #
 # NOTE: some older scripts have defective SEARCH, so we do CHECK if failed.
 
@@ -77,43 +79,60 @@ CPPFLAGS="${CPPFLAGS} AS_ESCAPE([-I${top_builddir}]) AS_ESCAPE([-I${top_srcdir}]
 have_libm=maybe
 AC_CHECK_HEADER([math.h],
   AC_SEARCH_LIBS([cos],[m],[have_libm=yes],
-    AC_CHECK_LIB([m],[cos],[have_libm=yes],
-      AC_CHECK_FUNC([cos],[have_libm=yes]))))
+    AC_CHECK_FUNC([cos],[have_libm=yes])))
 if test x"${have_libm}" != xyes; then
     AC_MSG_FAILURE([ERROR: Please install the Math library and math.h],[1])
 fi
 
 # Check for package fftw, else fftw3.h include file and fftw3 library. GPL
 have_libfftw=maybe
-PKG_CHECK_MODULES([FFTW],[fftw3 >= 3.0],[have_libfftw=yes pkg_cflags="${FFTW_CFLAGS}" pkg_libs="${FFTW_LIBS}"],[have_libfftw=no])
+PKG_CHECK_MODULES([FFTW],[fftw3 >= 3.0],[have_libfftw=yes],[have_libfftw=no])
 if test x"${have_libfftw}" != xyes; then
   AC_CHECK_HEADER([fftw3.h],
     AC_SEARCH_LIBS([fftw_plan_dft_r2c_2d],[fftw3],[have_libfftw=yes],
-      AC_CHECK_LIB([fftw3],[fftw_plan_dft_r2c_2d],[have_libfftw=yes],
-        AC_CHECK_FUNC([fftw_plan_dft_r2c_2d],[have_libfftw=yes]))))
+      AC_CHECK_FUNC([fftw_plan_dft_r2c_2d],[have_libfftw=yes])))
 fi
 if test x"${have_libfftw}" != xyes; then
    AC_MSG_FAILURE([ERROR: Please install the developer version of fftw3 library.],[1])
 fi
+AC_SUBST(FFTW_CFLAGS)
+AC_SUBST(FFTW_LIBS)
 
 # Check for libgimp/gimp.h include file and libgimp library. LGPL
+GIMP2_CFLAGS=
+GIMP2_LIBS=
+gimp2_bindir=
 have_libgimp=no
-PKG_CHECK_MODULES([GIMP],[gimp-2.0],[have_libgimp=yes pkg_cflags="${pkg_cflags} ${GIMP_CFLAGS}" pkg_libs="${pkg_libs} ${GIMP_LIBS}"],[have_libgimp=no])
+PKG_CHECK_MODULES([GIMP2],[gimp-2.0 >= 2.10.0 gimpui-2.0 >= 2.10.0],[have_libgimp=yes])
 if test x"${have_libgimp}" != xyes; then
-  AC_CHECK_HEADER([gimp.h],
-    AC_SEARCH_LIBS([gimp_install_procedure],[gimp],[have_libgimp=yes],
-      AC_CHECK_LIB([gimp],[gimp_install_procedure],[have_libgimp=yes],
-        AC_CHECK_FUNC([gimp_install_procedure],[have_libgimp=yes]))))
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp2.],[1])
 fi
-if test x"${have_libgimp}" != xyes; then
-    AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp.],[1])
+AC_SUBST(GIMP2_CFLAGS)
+AC_SUBST(GIMP2_LIBS)
+
+# Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
+gimp2_gimplibdir=`${PKG_CONFIG} --variable=gimplibdir gimp-2.0`
+gimp2_prefix=`${PKG_CONFIG} --variable=exec_prefix gimp-2.0`
+gimp2_relative=${gimp2_gimplibdir#$gimp2_prefix}
+GIMP2_BINDIR=\${exec_prefix}"$gimp2_relative"
+AC_SUBST(GIMP2_BINDIR)
+
+AM_CONDITIONAL([HAVEGIMPTOOL2],[test "${GIMPTOOL2}"x != x])
+
+# Fetch necessary flags for building gimp2 version of gimp-plugin-fourier
+GTK2_CFLAGS=
+GTK2_LIBS=
+have_libgtk=no
+PKG_CHECK_MODULES([GTK2],[gtk+-2.0],[have_libgtk=yes])
+if test x"${have_libgtk}" != xyes; then
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgtk+2.],[1])
 fi
+AC_SUBST(GTK2_CFLAGS)
+AC_SUBST(GTK2_LIBS)
 
 case "$build_os" in
   cygwin*|mingw32*|mingw64*)	BUILD_EXEEXT=.exe ;;
 esac
-
-AM_CONDITIONAL([HAVEGIMPTOOL],[test "${GIMPTOOL}"x != x])
 
 #--------------------------------------------------------------------------
 # Pass variables to fourier-config.h
@@ -126,20 +145,7 @@ AC_SUBST([FOURIER_MAJOR_VERSION],[fourier_major_version])
 AC_SUBST([FOURIER_MINOR_VERSION],[fourier_minor_version])
 AC_SUBST([FOURIER_VERSION],[fourier_version])
 AC_SUBST([CPPFLAGS],["$CPPFLAGS"])
-AC_SUBST([PKG_CFLAGS],["$pkg_cflags"])
-AC_SUBST([PKG_LIBS],["$pkg_libs"])
 AC_SUBST([HOST],["$host"])
-
-# Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
-GIMP_GIMPLIBDIR=`$PKG_CONFIG --variable=gimplibdir gimp-2.0`
-# Seems that gimp does not follow libdir of the distro, so just replacing prefix
-# GIMP_LIBDIR=`$PKG_CONFIG --variable=libdir gimp-2.0`
-# GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_LIBDIR}
-# GIMP_BINDIR="$libdir$GIMP_RELATIVE"
-GIMP_PREFIX=`$PKG_CONFIG --variable=exec_prefix gimp-2.0`
-GIMP_RELATIVE=${GIMP_GIMPLIBDIR#$GIMP_PREFIX}
-GIMP_BINDIR=\${exec_prefix}"$GIMP_RELATIVE"
-AC_SUBST(GIMP_BINDIR)
 
 #--------------------------------------------------------------------------
 # Put ifndef wrapper on fourier-config.h so we don't call it repeatedly.
@@ -161,12 +167,15 @@ Configuration:
 
   Source code location	${srcdir}
   Build code location	${builddir}
-  fourier bindir	${GIMP_BINDIR}
-  docs root dir		${datarootdir}
+  fourier bindir	${GIMP2_BINDIR}
   Compiler		${CC}
   cppflag		${CPPFLAGS}
-  pkg_cflag		${PKG_CFLAGS}
-  pkg_libs		${PKG_LIBS}
+  GIMP2_CFLAGS		${GIMP2_CFLAGS}
+  GIMP2_LIBS		${GIMP2_LIBS}
+  GTK2_CFLAGS		${GTK2_CFLAGS}
+  GTK2_LIBS		${GTK2_LIBS}
+  FFTW_CFLAGS		${FFTW_CFLAGS}
+  FFTW_LIBS		${FFTW_LIBS}
   CFLAGS		${CFLAGS}
   LIBS			${LIBS}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,10 @@ AC_PROG_MKDIR_P
 AC_PATH_PROG([STRIP],[strip],[:])
 AC_PATH_PROG([GIMPTOOL2],[gimptool-2.0],[:])
 AC_PATH_PROG([GIMPTOOL3],[gimptool-3.0],[:])
+AC_PATH_PROG([MSGFMT],[msgfmt],[:])
+AC_PATH_PROG([MSGINIT],[msginit],[:])
+AC_PATH_PROG([MSGMERGE],[msgmerge],[:])
+AC_PATH_PROG([XGETTEXT],[xgettext],[:])
 AM_CONFIG_HEADER(fourier-config.h)
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -98,6 +102,16 @@ if test x"${have_libfftw}" != xyes; then
 fi
 AC_SUBST(FFTW_CFLAGS)
 AC_SUBST(FFTW_LIBS)
+
+#--------------------------------------------------------------------------
+# Enable fourier dialog mode
+AC_ARG_ENABLE([fourier_dialog],
+  [AS_HELP_STRING([--enable-fourier_dialog],
+    [Enable fourier_dialog mode @<:@default=no@:>@])],
+  [],[enable_fourier_dialog=no])
+if test "x$enable_fourier_dialog" = xyes || test "x$enable_fourier_dialog" = xtrue ; then
+  AC_DEFINE([FOURIER_USE_DIALOG],1,[experimental, Define if using GIMP-3.0 style dialog.])
+fi
 
 #--------------------------------------------------------------------------
 # Enable make gimp3-plugin-fourier, and turn-off making gimp-plugin-fourier
@@ -157,6 +171,7 @@ AC_SUBST(GTK2_LIBS)
 GIMP3_CFLAGS=
 GIMP3_LIBS=
 GIMP3_BINDIR=
+SNIPPET1=
 if test x"${make_gimp3}" = xyes; then
   have_libgimp3=no
   PKG_CHECK_MODULES([GIMP3],[gimp-3.0 gimpui-3.0],[have_libgimp3=yes])
@@ -168,10 +183,21 @@ if test x"${make_gimp3}" = xyes; then
   gimp3_prefix=`${PKG_CONFIG} --variable=exec_prefix gimp-3.0`
   gimp3_relative=${gimp3_gimplibdir#$gimp3_prefix}
   GIMP3_BINDIR=\${exec_prefix}"$gimp3_relative"
+  dnl Do it here since automake can't process 'if/else/endif in Makefile.am
+  GIMP3_BINDIR=${gimp3_gimplibdir}/plug-ins/fourier
+  SNIPPET1='
+  ifeq ($(shell id -u),0)
+    bin3dir = $(GIMP3_BINDIR)
+  else
+    bin3dir = $(libdir)/gimp/3.0/plug-ins/fourier
+  endif
+  '
 fi
 AC_SUBST(GIMP3_CFLAGS)
 AC_SUBST(GIMP3_LIBS)
 AC_SUBST(GIMP3_BINDIR)
+AC_SUBST([SNIPPET1])
+AM_SUBST_NOTMAKE([SNIPPET1])
 
 AM_CONDITIONAL([HAVEGIMPTOOL3],[test "${GIMPTOOL3}"x != x])
 
@@ -188,6 +214,25 @@ fi
 AC_SUBST(GTK3_CFLAGS)
 AC_SUBST(GTK3_LIBS)
 
+# Avoid being locked to a particular gettext verion, use what's available.
+have_gettext=no
+GETTEXT_PACKAGE3=gimp30-fourier
+if test x"${make_gimp3}" = xyes; then
+  AC_CHECK_HEADERS([intl.h],[have_gettext=yes])
+  AC_CHECK_FUNC([gettext],[have_gettext=yes],[have_gettext=no])
+  AC_CHECK_FUNC([bind_textdomain_codeset],,[have_gettext=no])
+  AC_CHECK_FUNC([textdomain],,[have_gettext=no])
+  if test x"${have_gettext}" = xno; then
+    AC_SEARCH_LIBS([intl],[have_gettext=yes],[
+    AC_MSG_ERROR([ERROR: gettext() required! Please install libintl or GETTEXT Packages.])])
+  fi
+  AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE3, "$GETTEXT_PACKAGE3", [The gimp3 gettext translation domain.])
+  if test x"${have_gettext}" = xyes; then
+    AC_DEFINE([HAVE_GETTEXT],1,[Enable use of local languages])
+  fi
+fi
+AC_SUBST(GETTEXT_PACKAGE3)
+
 case "$build_os" in
   cygwin*|mingw32*|mingw64*)	BUILD_EXEEXT=.exe ;;
 esac
@@ -202,6 +247,8 @@ AC_DEFINE([FOURIER_MINOR_VERSION],["fourier_minor_version"],[gimp-plugin-fourier
 AC_SUBST([FOURIER_MAJOR_VERSION],[fourier_major_version])
 AC_SUBST([FOURIER_MINOR_VERSION],[fourier_minor_version])
 AC_SUBST([FOURIER_VERSION],[fourier_version])
+AC_SUBST([FOURIER_PACKAGE_NAME],[fourier_package_name])
+AC_SUBST([FOURIER_EMAIL],[fourier_package_email])
 AC_SUBST([CPPFLAGS],["$CPPFLAGS"])
 AC_SUBST([HOST],["$host"])
 
@@ -216,6 +263,7 @@ AH_BOTTOM([
 #--------------------------------------------------------------------------
 AC_CONFIG_FILES([
 Makefile
+po/Makefile
 rpm/gimp-fourier-plugin.spec
 rpm/gimp3-fourier-plugin.spec
 ])
@@ -227,17 +275,19 @@ Configuration:
   Source code location	${srcdir}
   Build code location	${builddir}
   Compiler		${CC}
-  cppflag		${CPPFLAGS}
+  CPPFLAGS		${CPPFLAGS}
 
-  make gimp2 fourier	${make_gimp2}
+  Make gimp2 fourier	${make_gimp2}
     fourier bindir	${GIMP2_BINDIR}
     GIMP2_CFLAGS	${GIMP2_CFLAGS}
     GIMP2_LIBS		${GIMP2_LIBS}
     GTK2_CFLAGS		${GTK2_CFLAGS}
     GTK2_LIBS		${GTK2_LIBS}
 
-  make gimp3 fourier3	${make_gimp3}
+  Make gimp3 fourier3	${make_gimp3}
     fourier3 bindir	${GIMP3_BINDIR}
+    Use language locale	${have_gettext}
+    fourier3 locale dir	${localedir}
     GIMP3_CFLAGS	${GIMP3_CFLAGS}
     GIMP3_LIBS		${GIMP3_LIBS}
     GTK3_CFLAGS		${GTK3_CFLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -187,9 +187,9 @@ if test x"${make_gimp3}" = xyes; then
   GIMP3_BINDIR=${gimp3_gimplibdir}/plug-ins/fourier
   SNIPPET1='
   ifeq ($(shell id -u),0)
-    bin3dir = $(GIMP3_BINDIR)
+    bin3dir += $(GIMP3_BINDIR)
   else
-    bin3dir = $(libdir)/gimp/3.0/plug-ins/fourier
+    bin3dir += $(libdir)/gimp/3.0/plug-ins/fourier
   endif
   '
 fi
@@ -284,10 +284,10 @@ Configuration:
     GTK2_CFLAGS		${GTK2_CFLAGS}
     GTK2_LIBS		${GTK2_LIBS}
 
-  Make gimp3 fourier3	${make_gimp3}
-    fourier3 bindir	${GIMP3_BINDIR}
+  Make gimp3 fourier	${make_gimp3}
+    fourier bindir	${GIMP3_BINDIR}
     Use language locale	${have_gettext}
-    fourier3 locale dir	${localedir}
+    fourier locale dir	${localedir}
     GIMP3_CFLAGS	${GIMP3_CFLAGS}
     GIMP3_LIBS		${GIMP3_LIBS}
     GTK3_CFLAGS		${GTK3_CFLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PATH_PROG([STRIP],[strip],[:])
 AC_PATH_PROG([GIMPTOOL2],[gimptool-2.0],[:])
+AC_PATH_PROG([GIMPTOOL3],[gimptool-3.0],[:])
 AM_CONFIG_HEADER(fourier-config.h)
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -68,7 +69,7 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],[AC_SUBST([AM_DEFAULT_VERBOS
 CPPFLAGS="${CPPFLAGS} AS_ESCAPE([-I${top_builddir}]) AS_ESCAPE([-I${top_srcdir}])"
 
 #--------------------------------------------------------------------------
-# Check for libraries.
+# Check for required libraries.
 # NOTE: Some distros don't have /usr/local included in the /etc/ld.so PATH,
 # so, PKG_CHECK_MODULES may not find libraries you compile into /usr/local,
 # therefore use AC_SEARCH_LIBS, AC_CHECK_FUNC for backup.
@@ -98,23 +99,43 @@ fi
 AC_SUBST(FFTW_CFLAGS)
 AC_SUBST(FFTW_LIBS)
 
-# Check for libgimp/gimp.h include file and libgimp library. LGPL
+#--------------------------------------------------------------------------
+# Enable make gimp3-plugin-fourier, and turn-off making gimp-plugin-fourier
+AC_ARG_ENABLE([gimp3_fourier],
+  [AS_HELP_STRING([--enable-gimp3-fourier],
+    [Enable gimp3-fourier, and disable gimp-fourier mode @<:@default=no@:>@])],
+  [gimp3_fourier=yes],[gimp3_fourier=no])
+make_gimp2=yes
+make_gimp3=no
+if test "x$gimp3_fourier" = xyes || test "x$gimp3_fourier" = xtrue ; then
+  make_gimp2=no
+  make_gimp3=yes
+fi
+AM_CONDITIONAL([MAKEGIMP2],[test "${make_gimp2}"x = yesx])
+AM_CONDITIONAL([MAKEGIMP3],[test "${make_gimp3}"x = yesx])
+
+#--------------------------------------------------------------------------
+# Check for libraries based on ./configure --enable choices.
+
+# Check for libgimp2/gimp.h include file and libgimp library. LGPL
 GIMP2_CFLAGS=
 GIMP2_LIBS=
-gimp2_bindir=
-have_libgimp=no
-PKG_CHECK_MODULES([GIMP2],[gimp-2.0 >= 2.10.0 gimpui-2.0 >= 2.10.0],[have_libgimp=yes])
-if test x"${have_libgimp}" != xyes; then
+GIMP2_BINDIR=
+if test x"${make_gimp2}" = xyes; then
+  have_libgimp2=no
+  PKG_CHECK_MODULES([GIMP2],
+                    [gimp-2.0 >= 2.10.0 gimpui-2.0 >= 2.10.0],[have_libgimp2=yes])
+  if test x"${have_libgimp2}" != xyes; then
     AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp2.],[1])
+  fi
+  # Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
+  gimp2_gimplibdir=`${PKG_CONFIG} --variable=gimplibdir gimp-2.0`
+  gimp2_prefix=`${PKG_CONFIG} --variable=exec_prefix gimp-2.0`
+  gimp2_relative=${gimp2_gimplibdir#$gimp2_prefix}
+  GIMP2_BINDIR=\${exec_prefix}"$gimp2_relative"
 fi
 AC_SUBST(GIMP2_CFLAGS)
 AC_SUBST(GIMP2_LIBS)
-
-# Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
-gimp2_gimplibdir=`${PKG_CONFIG} --variable=gimplibdir gimp-2.0`
-gimp2_prefix=`${PKG_CONFIG} --variable=exec_prefix gimp-2.0`
-gimp2_relative=${gimp2_gimplibdir#$gimp2_prefix}
-GIMP2_BINDIR=\${exec_prefix}"$gimp2_relative"
 AC_SUBST(GIMP2_BINDIR)
 
 AM_CONDITIONAL([HAVEGIMPTOOL2],[test "${GIMPTOOL2}"x != x])
@@ -122,13 +143,50 @@ AM_CONDITIONAL([HAVEGIMPTOOL2],[test "${GIMPTOOL2}"x != x])
 # Fetch necessary flags for building gimp2 version of gimp-plugin-fourier
 GTK2_CFLAGS=
 GTK2_LIBS=
-have_libgtk=no
-PKG_CHECK_MODULES([GTK2],[gtk+-2.0],[have_libgtk=yes])
-if test x"${have_libgtk}" != xyes; then
+if test x"${make_gimp2}" = xyes; then
+  have_libgtk=no
+  PKG_CHECK_MODULES([GTK2],[gtk+-2.0],[have_libgtk=yes])
+  if test x"${have_libgtk}" != xyes; then
     AC_MSG_FAILURE([ERROR: Please install the developer version of libgtk+2.],[1])
+  fi
 fi
 AC_SUBST(GTK2_CFLAGS)
 AC_SUBST(GTK2_LIBS)
+
+# Check for libgimp3/gimp.h include file and libgimp library. LGPL
+GIMP3_CFLAGS=
+GIMP3_LIBS=
+GIMP3_BINDIR=
+if test x"${make_gimp3}" = xyes; then
+  have_libgimp3=no
+  PKG_CHECK_MODULES([GIMP3],[gimp-3.0 gimpui-3.0],[have_libgimp3=yes])
+  if test x"${have_libgimp3}" != xyes; then
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgimp3.],[1])
+  fi
+  # Pass GIMP_LIBDIR to automake for default GIMP plug-ins directory
+  gimp3_gimplibdir=`${PKG_CONFIG} --variable=gimplibdir gimp-3.0`
+  gimp3_prefix=`${PKG_CONFIG} --variable=exec_prefix gimp-3.0`
+  gimp3_relative=${gimp3_gimplibdir#$gimp3_prefix}
+  GIMP3_BINDIR=\${exec_prefix}"$gimp3_relative"
+fi
+AC_SUBST(GIMP3_CFLAGS)
+AC_SUBST(GIMP3_LIBS)
+AC_SUBST(GIMP3_BINDIR)
+
+AM_CONDITIONAL([HAVEGIMPTOOL3],[test "${GIMPTOOL3}"x != x])
+
+# Fetch necessary flags for building gimp3 version of gimp-plugin-fourier
+GTK3_CFLAGS=
+GTK3_LIBS=
+if test x"${make_gimp3}" = xyes; then
+  have_libgtk3=no
+  PKG_CHECK_MODULES([GTK3],[gtk+-3.0],[have_libgtk3=yes])
+  if test x"${have_libgtk3}" != xyes; then
+    AC_MSG_FAILURE([ERROR: Please install the developer version of libgtk+3.],[1])
+  fi
+fi
+AC_SUBST(GTK3_CFLAGS)
+AC_SUBST(GTK3_LIBS)
 
 case "$build_os" in
   cygwin*|mingw32*|mingw64*)	BUILD_EXEEXT=.exe ;;
@@ -136,8 +194,8 @@ esac
 
 #--------------------------------------------------------------------------
 # Pass variables to fourier-config.h
-AC_DEFINE([FOURIER_MAJOR_VERSION],["fourier_major_version"],[gimp-fourier-plugin major version])
-AC_DEFINE([FOURIER_MINOR_VERSION],["fourier_minor_version"],[gimp-fourier-plugin minor version])
+AC_DEFINE([FOURIER_MAJOR_VERSION],["fourier_major_version"],[gimp-plugin-fourier major version])
+AC_DEFINE([FOURIER_MINOR_VERSION],["fourier_minor_version"],[gimp-plugin-fourier minor version])
 
 #--------------------------------------------------------------------------
 # Pass variables to several MAKEFILE.AM
@@ -159,6 +217,7 @@ AH_BOTTOM([
 AC_CONFIG_FILES([
 Makefile
 rpm/gimp-fourier-plugin.spec
+rpm/gimp3-fourier-plugin.spec
 ])
 AC_OUTPUT
 AC_MSG_NOTICE([
@@ -167,13 +226,23 @@ Configuration:
 
   Source code location	${srcdir}
   Build code location	${builddir}
-  fourier bindir	${GIMP2_BINDIR}
   Compiler		${CC}
   cppflag		${CPPFLAGS}
-  GIMP2_CFLAGS		${GIMP2_CFLAGS}
-  GIMP2_LIBS		${GIMP2_LIBS}
-  GTK2_CFLAGS		${GTK2_CFLAGS}
-  GTK2_LIBS		${GTK2_LIBS}
+
+  make gimp2 fourier	${make_gimp2}
+    fourier bindir	${GIMP2_BINDIR}
+    GIMP2_CFLAGS	${GIMP2_CFLAGS}
+    GIMP2_LIBS		${GIMP2_LIBS}
+    GTK2_CFLAGS		${GTK2_CFLAGS}
+    GTK2_LIBS		${GTK2_LIBS}
+
+  make gimp3 fourier3	${make_gimp3}
+    fourier3 bindir	${GIMP3_BINDIR}
+    GIMP3_CFLAGS	${GIMP3_CFLAGS}
+    GIMP3_LIBS		${GIMP3_LIBS}
+    GTK3_CFLAGS		${GTK3_CFLAGS}
+    GTK3_LIBS		${GTK3_LIBS}
+
   FFTW_CFLAGS		${FFTW_CFLAGS}
   FFTW_LIBS		${FFTW_LIBS}
   CFLAGS		${CFLAGS}

--- a/fourier.c
+++ b/fourier.c
@@ -287,18 +287,28 @@ void process_fft_inverse(guchar *src_pixels, guchar *dst_pixels, gint sel_width,
 
 /** GIMP Plugin Part ============================================================== **/
 
-#if (GIMP_MAJOR_VERSION == 3) || ((GIMP_MAJOR_VERSION == 2) && (GIMP_MINOR_VERSION >= 99))
+#if (MAKE_FOR_GIMP3)
 /** GIMP 3 *********************************************************/
 
 // based on hot.c bundled GIMP plugin
 
 #include <libgimp/gimpui.h>
 
-#define GETTEXT_PACKAGE "glib"
+#ifdef HAVE_GETTEXT
+#include <libintl.h>
+#define _(String) gettext (String)
+#ifdef gettext_noop
+#    define N_(String) gettext_noop (String)
+#else
+#    define N_(String) (String)
+#endif
+#else
+/* No i18n for now */
+#define _(x) x
+#define N_(x) x
+#endif
 
-#include "libgimp/stdplugins-intl.h"
-
-#define FOURIER_USE_DIALOG  false
+//#define FOURIER_USE_DIALOG  false
 
 typedef struct _Fourier Fourier;
 typedef struct _FourierClass FourierClass;
@@ -341,7 +351,7 @@ static gboolean plugin_dialog(GimpProcedure *procedure,
 G_DEFINE_TYPE(Fourier, fourier, GIMP_TYPE_PLUG_IN)
 
 GIMP_MAIN(FOURIER_TYPE)
-DEFINE_STD_SET_I18N
+//DEFINE_STD_SET_I18N use fourier po files
 
 typedef enum
 {
@@ -356,7 +366,7 @@ fourier_class_init(FourierClass *klass)
 
   plug_in_class->query_procedures = fourier_query_procedures;
   plug_in_class->create_procedure = fourier_create_procedure;
-  plug_in_class->set_i18n = STD_SET_I18N;
+  //plug_in_class->set_i18n = STD_SET_I18N; use fourier po files
 }
 
 static void
@@ -397,6 +407,16 @@ fourier_create_procedure(GimpPlugIn *plug_in,
     gimp_procedure_set_sensitivity_mask(procedure,
                                         GIMP_PROCEDURE_SENSITIVE_DRAWABLE);
 
+#ifdef HAVE_GETTEXT
+    /* Initialize i18n support */
+    setlocale (LC_ALL, "");
+    bindtextdomain (GETTEXT_PACKAGE3, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+    bind_textdomain_codeset (GETTEXT_PACKAGE3, "UTF-8");
+#endif
+    textdomain (GETTEXT_PACKAGE3);
+#endif
+
     gimp_procedure_set_menu_label(procedure, _("_Fourier..."));
     gimp_procedure_add_menu_path(procedure, PLUG_IN_MENU_LOCATION);
 
@@ -433,6 +453,16 @@ fourier_create_procedure(GimpPlugIn *plug_in,
     gimp_procedure_set_image_types(procedure, "RGB");
     gimp_procedure_set_sensitivity_mask(procedure,
                                         GIMP_PROCEDURE_SENSITIVE_DRAWABLE);
+
+#ifdef HAVE_GETTEXT
+    /* Initialize i18n support */
+    setlocale (LC_ALL, "");
+    bindtextdomain (GETTEXT_PACKAGE3, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+    bind_textdomain_codeset (GETTEXT_PACKAGE3, "UTF-8");
+#endif
+    textdomain (GETTEXT_PACKAGE3);
+#endif
 
     gimp_procedure_set_menu_label(procedure, _(PLUG_IN_DIR_MENU_LABEL));
     gimp_procedure_add_menu_path(procedure, PLUG_IN_MENU_LOCATION);
@@ -606,6 +636,16 @@ fourier_run(GimpProcedure *procedure,
   gboolean inverse = FALSE;
   gboolean new_layer = FALSE;
 
+#ifdef HAVE_GETTEXT
+  /* Initialize i18n support */
+  setlocale (LC_ALL, "");
+  bindtextdomain (GETTEXT_PACKAGE3, gimp_locale_directory ());
+#ifdef HAVE_BIND_TEXTDOMAIN_CODESET
+  bind_textdomain_codeset (GETTEXT_PACKAGE3, "UTF-8");
+#endif
+  textdomain (GETTEXT_PACKAGE3);
+#endif
+
   gegl_init(NULL, NULL);
 
   if (n_drawables != 1)
@@ -715,7 +755,8 @@ plugin_dialog(GimpProcedure *procedure,
 
 #endif
 
-#elif GIMP_MAJOR_VERSION == 2
+#endif
+#if (!MAKE_FOR_GIMP3)
 /** GIMP 2 *********************************************************/
 
 
@@ -899,7 +940,5 @@ run(const gchar *name,
   }
 }
 
-#else
-#error "Unsupported GIMP version"
 #endif
 

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -1,0 +1,56 @@
+LANGUAGES = fr
+PO_FILES = fr.po
+
+# This information is here to help translators create/update (pot/po files):
+#
+# To create a new pot file, you need to cd into this po directory first:
+#   cd po
+#   del gimp30-fourier.pot
+#   make update-pot
+#
+# To update existing po files you need to cd into po directory and then do:
+#   cd po
+#   make update-po
+#
+
+.PHONY: all install uninstall clean $(LANGUAGES)
+.PHONY: update-po update-pot
+
+all: $(LANGUAGES)
+
+$(LANGUAGES):
+	if [[ -e $(srcdir)/$@.po ]]; \
+	then $(MSGFMT) -c -v -o $(builddir)/$@.mo $(srcdir)/$@.po; \
+	else $(MSGFMT) -c -v -o $(builddir)/$@.mo $(builddir)/$@.po; \
+	fi
+
+update-po: $(PO_FILES)
+
+$(PO_FILES): $(GETTEXT_PACKAGE3).pot
+	if [[ -e $(srcdir)/$@ ]]; \
+	then $(MSGMERGE) -U $(srcdir)/$@ $^; \
+	else $(MSGFMT) -l $(subst .po,,$@) -o $(builddir)/$@ -i $^; \
+	fi
+
+install-data-local: $(LANGUAGES)
+	for L in $(LANGUAGES); \
+	do $(MKDIR_P) -p "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES"; \
+	install -v -m 0644 $(builddir)/$$L.mo "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES/$(GETTEXT_PACKAGE3).mo"; \
+	done
+
+uninstall-local: $(LANGUAGES)
+	for L in $(LANGUAGES); \
+	do rm -vf "$(DESTDIR)$(localedir)/$$L/LC_MESSAGES/$(GETTEXT_PACKAGE3).mo"; \
+	done
+
+clean-local:
+	rm -f *.po~ *.mo *.mo~
+
+update-pot: $(GETTEXT_PACKAGE3).pot
+
+$(GETTEXT_PACKAGE3).pot:
+	$(XGETTEXT) -k_ -k_\" -d $(GETTEXT_PACKAGE3) -o $@ \
+	--package-version=$(FOURIER_VERSION) --msgid-bugs-address=$(FOURIER_EMAIL) \
+	../*.c
+
+EXTRA_DIST = $(PO_FILES) $(GETTEXT_PACKAGE3).pot

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,55 @@
+# gimp3-fourier-plugin
+# Copyright (C) 2024
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gimp30-fourier-plugin\n"
+"Report-Msgid-Bugs-To: https://github.com/rpeyron/plugin-gimp-fourier/issues\n"
+"POT-Creation-Date: 2024-05-21 15:18-0700\n"
+"PO-Revision-Date: 2024-05-21 00:00+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../fourier.c:420
+msgid "_Fourier..."
+msgstr ""
+
+#: ../fourier.c:433
+msgid "Mode"
+msgstr ""
+
+#: ../fourier.c:434
+msgid "Mode { Foward (0), Inversed (1) }"
+msgstr ""
+
+#: ../fourier.c:439
+msgid "Create _new layer"
+msgstr ""
+
+#: ../fourier.c:440
+msgid "Create a new layer"
+msgstr ""
+
+#: ../fourier.c:656
+#, c-format
+msgid "Procedure '%s' only works with one drawable."
+msgstr ""
+
+#: ../fourier.c:710
+msgid "Fourier"
+msgstr ""
+
+#: ../fourier.c:719
+msgid "_Forward"
+msgstr ""
+
+#: ../fourier.c:720
+msgid "_Inverse"
+msgstr ""

--- a/po/gimp30-fourier.pot
+++ b/po/gimp30-fourier.pot
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://github.com/rpeyron/plugin-gimp-fourier/issues\n"
+"POT-Creation-Date: 2024-05-21 15:53-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../fourier.c:420
+msgid "_Fourier..."
+msgstr ""
+
+#: ../fourier.c:433
+msgid "Mode"
+msgstr ""
+
+#: ../fourier.c:434
+msgid "Mode { Foward (0), Inversed (1) }"
+msgstr ""
+
+#: ../fourier.c:439
+msgid "Create _new layer"
+msgstr ""
+
+#: ../fourier.c:440
+msgid "Create a new layer"
+msgstr ""
+
+#: ../fourier.c:656
+#, c-format
+msgid "Procedure '%s' only works with one drawable."
+msgstr ""
+
+#: ../fourier.c:710
+msgid "Fourier"
+msgstr ""
+
+#: ../fourier.c:719
+msgid "_Forward"
+msgstr ""
+
+#: ../fourier.c:720
+msgid "_Inverse"
+msgstr ""

--- a/rpm/gimp-fourier-plugin.spec.in
+++ b/rpm/gimp-fourier-plugin.spec.in
@@ -5,51 +5,51 @@
 # This file and all modifications and additions to the pristine
 # package are under the same license as the package itself.
 # Modified for autoconf style build by Joe Da Silva (v0.4.3)
+# additional mods made here based on fedoraproject and mageia:
+# https://src.fedoraproject.org/rpms/gimp-fourier-plugin/blob/rawhide/f/gimp-fourier-plugin.spec
+# http://sophie.zarb.org/rpms/28ff35b74220354ba52644c97293d4dd/files/1
 #
-Name:		gimp-plugin-fourier
+Name:		gimp-fourier-plugin
 Version:	@FOURIER_VERSION@
 Release:	0
 Summary:	Do direct and reverse Fourier Transforms on your image
 License:	GPLv3+
 URL:		https://www.lprp.fr/gimp_plugin_en/
 Group:          Productivity/Graphics/Bitmap Editors
-Source0:	https://github.com/rpeyron/plugin-gimp-fourier/releases/download/v%{version}/gimp-plugin-fourier-%{version}.tar.gz
+Source0:	https://github.com/rpeyron/plugin-gimp-fourier/archive/v%{version}/plugin-gimp-fourier-%{version}.tar.gz
 BuildRequires:	autoconf
 BuildRequires:	automake
 BuildRequires:	gcc
 BuildRequires:	make
 BuildRequires:  pkgconfig(fftw3)
 BuildRequires:  pkgconfig(gimp-2.0)
+BuildRequires:	pkgconfig(gtk+-2.0)
 Requires:       gimp
 Requires:       libfftw3
 
 %description
-GIMP Plugin to do forward and reverse Fourier Transform. The major advantage
-of this plugin is to be able to work with the transformed image inside GIMP.
-You can draw or apply filters in fourier space and get the modified image
-with an inverse fourier transform.
-Useful in fixing moire patterns or fixing some regular banding noise.
+GIMP Plugin to do forward and reverse Fourier Transform. The major advantage of
+this plugin is to be able to work with the transformed image inside GIMP. You
+can draw or apply filters in fourier space and get the modified image with an
+inverse fourier transform. Useful in fixing moire patterns or fixing some
+regular banding noise.
 
 %prep
-%setup ‑q
+%setup -n plugin-gimp-fourier-%{version}
 
 %build
-#%autoreconf -i
-#%automake
-%configure --bindir=%{_libdir}/gimp/2.0/plug-ins
+autoreconf --force --install --verbose
+%configure
 %make_build
 
 %install
-# We can’t use “gimptool-2.0 install-bin” to install into plug-ins directory.
-# We therefore don’t need gimptool-2.0 at all.
-%make_install bindir=%{_libdir}/gimp/2.0/plug-ins datadir=%{_datadir}
+%make_install
 
 # Upstream provides no tests.
 
 %files
-%doc %{_datadir}/gimp-fourier-plugin/LICENSE
-%doc %{_datadir}/gimp-fourier-plugin/README.md
-%doc %{_datadir}/gimp-fourier-plugin/README.Moire
+%license LICENSE
+%doc README.md README.Moire
 %{_libdir}/gimp/2.0/plug-ins/fourier
 
 %changelog

--- a/rpm/gimp3-fourier-plugin.spec.in
+++ b/rpm/gimp3-fourier-plugin.spec.in
@@ -9,6 +9,8 @@
 # https://src.fedoraproject.org/rpms/gimp-fourier-plugin/blob/rawhide/f/gimp-fourier-plugin.spec
 # http://sophie.zarb.org/rpms/28ff35b74220354ba52644c97293d4dd/files/1
 #
+%define         moname    gimp30-fourier
+
 Name:		gimp3-fourier-plugin
 Version:	@FOURIER_VERSION@
 Release:	0
@@ -46,10 +48,11 @@ autoreconf --force --install --verbose
 
 %install
 %make_install
+%find_lang %{moname}
 
 # Upstream provides no tests.
 
-%files
+%files -f %{moname}.lang
 %license LICENSE
 %doc README.md
 %doc README.Moire

--- a/rpm/gimp3-fourier-plugin.spec.in
+++ b/rpm/gimp3-fourier-plugin.spec.in
@@ -56,6 +56,6 @@ autoreconf --force --install --verbose
 %license LICENSE
 %doc README.md
 %doc README.Moire
-%{_libdir}/gimp/3.0/plug-ins/fourier/fourier3
+%{_libdir}/gimp/3.0/plug-ins/fourier/fourier
 
 %changelog

--- a/rpm/gimp3-fourier-plugin.spec.in
+++ b/rpm/gimp3-fourier-plugin.spec.in
@@ -1,15 +1,15 @@
 #
-# spec file for package gimp-fourier-plugin
+# spec file for package gimp3-fourier-plugin
 #
 # Copyright (c) 2011 Kyrill Detinov (Version 0.4.1)
 # This file and all modifications and additions to the pristine
 # package are under the same license as the package itself.
-# Modified for autoconf style build by Joe Da Silva (v0.4.3)
+# Modified for autoconf style build by Joe Da Silva
 # additional mods made here based on fedoraproject and mageia:
 # https://src.fedoraproject.org/rpms/gimp-fourier-plugin/blob/rawhide/f/gimp-fourier-plugin.spec
 # http://sophie.zarb.org/rpms/28ff35b74220354ba52644c97293d4dd/files/1
 #
-Name:		gimp-fourier-plugin
+Name:		gimp3-fourier-plugin
 Version:	@FOURIER_VERSION@
 Release:	0
 Summary:	Do direct and reverse Fourier Transforms on your image
@@ -21,15 +21,17 @@ BuildRequires:	autoconf
 BuildRequires:	automake
 BuildRequires:	gcc
 BuildRequires:	make
+BuildRequires:	libtool
+
 BuildRequires:  pkgconfig(fftw3)
-BuildRequires:  pkgconfig(gimp-2.0)
-BuildRequires:	pkgconfig(gtk+-2.0)
-Requires:       gimp
-#Requires:       libfftw3
+BuildRequires:  pkgconfig(gimp-3.0)
+BuildRequires:  pkgconfig(gtk+-3.0)
+#Requires:       gimp-3.0
+#Requires:       lib64fftw3
 
 %description
-GIMP Plugin to do forward and reverse Fourier Transform. The major advantage of
-this plugin is to be able to work with the transformed image inside GIMP. You
+GIMP3 Plugin to do forward and reverse Fourier Transform. The major advantage of
+this plugin is to be able to work with the transformed image inside GIMP3. You
 can draw or apply filters in fourier space and get the modified image with an
 inverse fourier transform. Useful in fixing moire patterns or fixing some
 regular banding noise.
@@ -39,7 +41,7 @@ regular banding noise.
 
 %build
 autoreconf --force --install --verbose
-%configure
+%configure --enable-gimp3-fourier
 %make_build
 
 %install
@@ -49,7 +51,8 @@ autoreconf --force --install --verbose
 
 %files
 %license LICENSE
-%doc README.md README.Moire
-%{_libdir}/gimp/2.0/plug-ins/fourier
+%doc README.md
+%doc README.Moire
+%{_libdir}/gimp/3.0/plug-ins/fourier/fourier3
 
 %changelog


### PR DESCRIPTION
This closes PR #8 when merged.
As per PR#8 this will build gimp/2.0/plugin/fourier or gimp/3.0/plugin/fourier/fourier3

What was noted in earlier PR was the naming conventions, and it seemed important to maintain continuity with gimp-fourier-plugin for Fedora, Mageia, and some other Distros using that existing naming convention.
Also noted that the registry used gimp-plugin-fourier, so we need to also allow for that too.

Just need to add one more patch to add GETTEXT support.
Will try get that done tomorrow.

NOTE: This was tested for gimp3 using gimp-2.99.19 RC0 or higher
NOTE: gimp3 still contains gimptool-2.99
NOTE: .github/workflows/main.yml is not setup for gimp3 yet.

Your method of fetching gimp prefix also seems preferable to the SNIPPETS done in PR #8