### PR TITLE
Differences between 'make dist' for gimp2 and gimp3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,10 @@ EXTRA_DIST = LICENSE Makefile.gimptool		\
 	rpm/gimp-fourier-plugin.spec.in		\
 	rpm/gimp3-fourier-plugin.spec.in
 nodist_EXTRA_DATA = .git .github .deps .libs
-DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules --enable-silent-rules --enable-fourier_dialog
+DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules --enable-silent-rules
+if MAKEGIMP3
+DISTCHECK_CONFIGURE_FLAGS += --enable-fourier_dialog
+endif
 
 strip:
 	$(STRIP) ${builddir}/fourier


### PR DESCRIPTION
./configure --enable-fourier only used in gimp3, not in gimp2.
This caused a debuginfo problem in `rpmbuild -ba`
Problem resolved.

NOTE: rpm sample spec files are based on importing Source0 from:
https://github.com/rpeyron/plugin-gimp-fourier/archive/v%{version}/plugin-gimp-fourier-%{version}.tar.gz

To synthesize a source tar.gz of HEAD which is out of step with the archive/v%{version} for the `rpmbuild -ba` this requires a few steps:
```
autoreconf -i
automake
./configure (for gimp2 or for gimp3 use ./configure --enable-gimp3)
make dist
```
this builds gimp-fourier-plugin-{version}.tar.gz which the 'make dist' file is set for, but the spec file is looking for plugin-gimp-fourier-{version}.tar.gz, therefore you need to do this next
```
tar -xzf gimp-fourier-plugin-{version}.tar.gz
mv gimp-fourier-plugin-{version} plugin-gimp-fourier-{version}
tar -czf plugin-gimp-fourier-{version}.tar.gz plugin-gimp-fourier-{version}
```
then copy plugin-gimp-fourier-{version}.tar.gz into rpmbuild/SOURCES/ and then you can now run `rpmbuild -ba ~/rpmbuild/SPECS/gimp(3)-fourier-plugin-{version}.tar.gz`

It's quite a few steps for getting HEAD, but this lets the rpm project continue to be named gimp-fourier-plugin, easiest thing for the user is to simply wait for the next tag/release and fetch https://github.com/rpeyron/plugin-gimp-fourier/archive/v%{version}/plugin-gimp-fourier-%{version}.tar.gz